### PR TITLE
Feature: enable Java 1.8 features

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="lib" path="lib/derby.jar"/>
 	<classpathentry kind="lib" path="lib/iText-2.1.7.jar"/>
 	<classpathentry kind="lib" path="lib-dev/junit-4.7.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -4,8 +4,8 @@
 
 	<property environment="env" />
 	<property name="debuglevel" value="source,lines,vars" />
-	<property name="target" value="1.6" />
-	<property name="source" value="1.6" />
+	<property name="target" value="1.8" />
+	<property name="source" value="1.8" />
 
 	<property name="dir.src" location="src" />
 	<property name="dir.lib" location="lib" />
@@ -217,7 +217,7 @@
 	<target name="build-jarbundler" if="isMacOSX" description="Generate runnable app file for Mac OS X">
 		<taskdef name="jarbundler" classname="net.sourceforge.jarbundler.JarBundler" classpath="${dir.lib.dev}/jarbundler-2.1.0.jar" />
 
-		<jarbundler dir="${dir.dist}" name="${appName}" mainclass="org.revager.Main" jar="${dir.dist}/${appFileName}_${appVersion}.jar" build="${appBuild}" version="${appVersion}" bundleid="org.revager" icon="${dir.src}/org/revager/resources/build/macosx/appIcon.icns" jvmversion="1.6+" shortname="${appName}" />
+		<jarbundler dir="${dir.dist}" name="${appName}" mainclass="org.revager.Main" jar="${dir.dist}/${appFileName}_${appVersion}.jar" build="${appBuild}" version="${appVersion}" bundleid="org.revager" icon="${dir.src}/org/revager/resources/build/macosx/appIcon.icns" jvmversion="1.8+" shortname="${appName}" />
 	</target>
 
 


### PR DESCRIPTION
Enable Java 1.8 for ant and in classpath.

JAR tested on linux and exe tested on windows. Didn't/Cannot test OSX build.