### PR TITLE
Fix: remove dozens of warnings due to '_'-method

### DIFF
--- a/src/org/revager/Main.java
+++ b/src/org/revager/Main.java
@@ -18,7 +18,7 @@
  */
 package org.revager;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 import java.io.IOException;
@@ -111,7 +111,7 @@ public class Main {
 
 			SwingUtilities.invokeLater(ui);
 		} catch (Exception e) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 
 			System.err.println(e.getMessage());
@@ -161,8 +161,8 @@ public class Main {
 		} catch (Exception e) {
 			JOptionPane.showMessageDialog(UI.getInstance().getMainFrame(),
 					GUITools.getMessagePane(
-							_("The application cannot be restarted automatically on your system. Please start up RevAger manually after it has been closed.")),
-					_("Warning"), JOptionPane.WARNING_MESSAGE);
+							translate("The application cannot be restarted automatically on your system. Please start up RevAger manually after it has been closed.")),
+					translate("Warning"), JOptionPane.WARNING_MESSAGE);
 		}
 
 		exitApplication();
@@ -239,12 +239,12 @@ public class Main {
 		if (oldDataPathFound && newDataPathFound && !newDataPathExist) {
 			if (JOptionPane.showConfirmDialog(null,
 					GUITools.getMessagePane(
-							_("RevAger has detected an existing review data folder from an earlier version of this application. Do you want to use the data for the new version of RevAger?")),
-					_("Question"), JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
+							translate("RevAger has detected an existing review data folder from an earlier version of this application. Do you want to use the data for the new version of RevAger?")),
+					translate("Question"), JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
 				try {
 					FileTools.copyDirectory(new File(oldDataPath), new File(newDataPath));
 				} catch (IOException e) {
-					JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+					JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 							JOptionPane.ERROR_MESSAGE);
 
 					System.err.println(e.getMessage());

--- a/src/org/revager/app/ApplicationControl.java
+++ b/src/org/revager/app/ApplicationControl.java
@@ -18,7 +18,7 @@
  */
 package org.revager.app;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 import java.io.IOException;
@@ -167,7 +167,7 @@ public class ApplicationControl {
 	public synchronized void storeReview(String filePath) throws ResiIOException, IOException, ApplicationException {
 		if (filePath.startsWith(Data.getInstance().getAppData().getAppDataPath())) {
 			throw new ApplicationException(
-					_("It is not possible to store and open application data. Please choose another location."));
+					translate("It is not possible to store and open application data. Please choose another location."));
 		}
 
 		if (!filePath.trim().equals("") && !filePath.toLowerCase().trim().endsWith(ENDING_ZIP)
@@ -211,7 +211,7 @@ public class ApplicationControl {
 	public synchronized void loadReview(String filePath) throws ResiIOException, IOException, ApplicationException {
 		if (filePath.startsWith(Data.getInstance().getAppData().getAppDataPath())) {
 			throw new ApplicationException(
-					_("It is not possible to store and open application data. Please choose another location."));
+					translate("It is not possible to store and open application data. Please choose another location."));
 		}
 
 		if (filePath.toLowerCase().trim().endsWith(ENDING_ZIP)) {
@@ -378,13 +378,13 @@ public class ApplicationControl {
 		if (!reviewName.equals("")) {
 			reviewFileName += reviewName;
 		} else if (!productName.equals("")) {
-			reviewFileName += _("Review") + "_" + productName;
+			reviewFileName += translate("Review") + "_" + productName;
 
 			if (!productVersion.equals("")) {
 				reviewFileName += "_" + productVersion;
 			}
 		} else {
-			reviewFileName += _("Review");
+			reviewFileName += translate("Review");
 		}
 
 		return reviewFileName;

--- a/src/org/revager/app/FindingManagement.java
+++ b/src/org/revager/app/FindingManagement.java
@@ -289,7 +289,7 @@ public class FindingManagement {
 	 * @return The localized severity
 	 */
 	public String getLocalizedSeverity(Finding find) {
-		return Data._(find.getSeverity());
+		return Data.translate(find.getSeverity());
 	}
 
 	/**

--- a/src/org/revager/app/ImportExportControl.java
+++ b/src/org/revager/app/ImportExportControl.java
@@ -18,7 +18,7 @@
  */
 package org.revager.app;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 import java.text.DateFormat;
@@ -269,7 +269,7 @@ public class ImportExportControl {
 
 			exporter.writeToFile(filePath);
 		} else {
-			throw new ApplicationException(_("There aren't any findings to export into a CSV file."));
+			throw new ApplicationException(translate("There aren't any findings to export into a CSV file."));
 		}
 
 		return new File(filePath);
@@ -312,7 +312,7 @@ public class ImportExportControl {
 
 			exporter.writeToFile(filePath);
 		} else {
-			throw new ApplicationException(_("There aren't any findings to export into a CSV file."));
+			throw new ApplicationException(translate("There aren't any findings to export into a CSV file."));
 		}
 
 		return new File(filePath);
@@ -386,8 +386,8 @@ public class ImportExportControl {
 		Role.values();
 
 		for (Attendee att : attendees) {
-			invitationPackName = _("Review Invitation") + " " + sdf.format(new Date().getTime()) + " " + att.getName()
-					+ " (" + _(att.getRole().toString()) + ")";
+			invitationPackName = translate("Review Invitation") + " " + sdf.format(new Date().getTime()) + " " + att.getName()
+					+ " (" + translate(att.getRole().toString()) + ")";
 
 			invitationPackName = FileTools.validateFileName(invitationPackName);
 

--- a/src/org/revager/app/ResiFileFilter.java
+++ b/src/org/revager/app/ResiFileFilter.java
@@ -18,7 +18,7 @@
  */
 package org.revager.app;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -193,43 +193,43 @@ public class ResiFileFilter extends FileFilter implements FilenameFilter {
 
 		switch (type) {
 		case TYPE_ALL:
-			description = _("All files");
+			description = translate("All files");
 			break;
 
 		case TYPE_DIRECTORY:
-			description = _("Directory");
+			description = translate("Directory");
 			break;
 
 		case TYPE_REVIEW:
-			description = _("Review files") + " (*" + ENDING_REVIEW_ZIP + " *" + ENDING_REVIEW_XML + " *.xml)";
+			description = translate("Review files") + " (*" + ENDING_REVIEW_ZIP + " *" + ENDING_REVIEW_XML + " *.xml)";
 			break;
 
 		case TYPE_CATALOG:
-			description = _("Catalog files") + " (*" + ENDING_CATALOG + " *.xml)";
+			description = translate("Catalog files") + " (*" + ENDING_CATALOG + " *.xml)";
 			break;
 
 		case TYPE_ASPECTS:
-			description = _("Aspect files") + " (*" + ENDING_ASPECTS + " *.xml)";
+			description = translate("Aspect files") + " (*" + ENDING_ASPECTS + " *.xml)";
 			break;
 
 		case TYPE_PDF:
-			description = _("PDF files") + " (*.pdf)";
+			description = translate("PDF files") + " (*.pdf)";
 			break;
 
 		case TYPE_CSV:
-			description = _("CSV files") + " (*.csv *.txt)";
+			description = translate("CSV files") + " (*.csv *.txt)";
 			break;
 
 		case TYPE_ZIP:
-			description = _("ZIP files") + " (*.zip)";
+			description = translate("ZIP files") + " (*.zip)";
 			break;
 
 		case TYPE_IMAGES:
-			description = _("Image files") + " (*.jpg *.jpeg *.gif *.png)";
+			description = translate("Image files") + " (*.jpg *.jpeg *.gif *.png)";
 			break;
 
 		default:
-			description = _("All files");
+			description = translate("All files");
 			break;
 		}
 

--- a/src/org/revager/app/ReviewManagement.java
+++ b/src/org/revager/app/ReviewManagement.java
@@ -18,7 +18,7 @@
  */
 package org.revager.app;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 import java.io.IOException;
@@ -72,7 +72,7 @@ public class ReviewManagement {
 	/**
 	 * The review info document file name.
 	 */
-	private final String REVIEW_INFO_DOC = _("Review_Information.pdf");
+	private final String REVIEW_INFO_DOC = translate("Review_Information.pdf");
 
 	/**
 	 * The prefix to store external references in XML file.
@@ -830,7 +830,7 @@ public class ReviewManagement {
 	 * @return recommendation of the review
 	 */
 	public String getRecommendation() {
-		return Data._(resiData.getReview().getRecommendation());
+		return Data.translate(resiData.getReview().getRecommendation());
 	}
 
 	/**

--- a/src/org/revager/app/SeverityManagement.java
+++ b/src/org/revager/app/SeverityManagement.java
@@ -130,7 +130,7 @@ public class SeverityManagement {
 		List<String> list = new ArrayList<String>();
 
 		for (String sev : getDefLangSeverities()) {
-			list.add(Data._(sev));
+			list.add(Data.translate(sev));
 		}
 
 		return list;

--- a/src/org/revager/app/model/ApplicationData.java
+++ b/src/org/revager/app/model/ApplicationData.java
@@ -18,7 +18,7 @@
  */
 package org.revager.app.model;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 import java.sql.Connection;
@@ -159,7 +159,7 @@ public class ApplicationData extends Observable {
 				 * thrown if there occurs an internal error while creating the
 				 * tables.
 				 */
-				throw new DataException(_("Cannot create tables in the database.") + " [ERROR = " + e.getErrorCode()
+				throw new DataException(translate("Cannot create tables in the database.") + " [ERROR = " + e.getErrorCode()
 						+ " " + e.getMessage() + "]");
 			}
 
@@ -194,7 +194,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_(
+			throw new DataException(translate(
 					"Cannot open or create the database for storing application data. Maybe RevAger is running already."));
 		}
 
@@ -495,7 +495,7 @@ public class ApplicationData extends Observable {
 		ps.executeUpdate();
 
 		ps.setString(1, AppSettingKey.PDF_INVITATION_TEXT.toString());
-		ps.setString(2, _(Data.getDefLangInvitationText()));
+		ps.setString(2, translate(Data.getDefLangInvitationText()));
 		ps.executeUpdate();
 
 		/*
@@ -651,7 +651,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot retrieve the requested application settings.") + " [SETTING = " + key
+			throw new DataException(translate("Cannot retrieve the requested application settings.") + " [SETTING = " + key
 					+ "] " + e.getMessage());
 		}
 
@@ -659,7 +659,7 @@ public class ApplicationData extends Observable {
 		 * Translate the invitation text
 		 */
 		if (key == AppSettingKey.PDF_INVITATION_TEXT && setting.equals(Data.getDefLangInvitationText())) {
-			setting = _(setting);
+			setting = translate(setting);
 		}
 
 		return setting;
@@ -706,7 +706,7 @@ public class ApplicationData extends Observable {
 		/*
 		 * Check if the translation text is the original one
 		 */
-		if (key == AppSettingKey.PDF_INVITATION_TEXT && value.equals(_(Data.getDefLangInvitationText()))) {
+		if (key == AppSettingKey.PDF_INVITATION_TEXT && value.equals(translate(Data.getDefLangInvitationText()))) {
 			value = Data.getDefLangInvitationText();
 		}
 
@@ -736,7 +736,7 @@ public class ApplicationData extends Observable {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot store application settings.") + " [SETTING = " + key + "] " + e.getMessage());
+					translate("Cannot store application settings.") + " [SETTING = " + key + "] " + e.getMessage());
 		}
 	}
 
@@ -791,7 +791,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot load the list of recent reviews.") + " " + e.getMessage());
+			throw new DataException(translate("Cannot load the list of recent reviews.") + " " + e.getMessage());
 		}
 
 		return lastReviews;
@@ -850,7 +850,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot add the current review to the list of recent reviews.") + " (" + filePath
+			throw new DataException(translate("Cannot add the current review to the list of recent reviews.") + " (" + filePath
 					+ ") " + e.getMessage());
 		}
 	}
@@ -883,7 +883,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot remove the review from the list of recent reviews.") + " (" + filePath
+			throw new DataException(translate("Cannot remove the review from the list of recent reviews.") + " (" + filePath
 					+ ") " + e.getMessage());
 		}
 	}
@@ -919,7 +919,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot load catalogs from the catalog library.") + " " + e.getMessage());
+			throw new DataException(translate("Cannot load catalogs from the catalog library.") + " " + e.getMessage());
 		}
 
 		return catalogs;
@@ -986,7 +986,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot find requested catalog.") + " [NAME = " + name + "] " + e.getMessage());
+			throw new DataException(translate("Cannot find requested catalog.") + " [NAME = " + name + "] " + e.getMessage());
 		}
 
 		return catalog;
@@ -1120,7 +1120,7 @@ public class ApplicationData extends Observable {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("An error occured while removing a catalog.") + " [NAME = " + name + "] " + e.getMessage());
+					translate("An error occured while removing a catalog.") + " [NAME = " + name + "] " + e.getMessage());
 		}
 	}
 
@@ -1167,7 +1167,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the number of catalogs in the library.") + " " + e.getMessage());
+			throw new DataException(translate("Cannot get the number of catalogs in the library.") + " " + e.getMessage());
 		}
 
 		return numberOfCatalogs;
@@ -1204,7 +1204,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the first sorting position of the catalogs.") + " " + e.getMessage());
+			throw new DataException(translate("Cannot get the first sorting position of the catalogs.") + " " + e.getMessage());
 		}
 
 		return sortPos;
@@ -1241,7 +1241,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the last sorting position of the catalogs.") + " " + e.getMessage());
+			throw new DataException(translate("Cannot get the last sorting position of the catalogs.") + " " + e.getMessage());
 		}
 
 		return sortPos;
@@ -1277,7 +1277,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot load attendees from the database.") + " " + e.getMessage());
+			throw new DataException(translate("Cannot load attendees from the database.") + " " + e.getMessage());
 		}
 
 		return attendees;
@@ -1356,7 +1356,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot find requested attendee. The requested attendee may not be existing.")
+			throw new DataException(translate("Cannot find requested attendee. The requested attendee may not be existing.")
 					+ " [NAME = " + name + "] " + e.getMessage());
 		}
 
@@ -1439,7 +1439,7 @@ public class ApplicationData extends Observable {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("An error occurred while removing an attendee.") + " [NAME = " + name + "] " + e.getMessage());
+					translate("An error occurred while removing an attendee.") + " [NAME = " + name + "] " + e.getMessage());
 		}
 	}
 
@@ -1486,7 +1486,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the number of attendees in the database.") + " " + e.getMessage());
+			throw new DataException(translate("Cannot get the number of attendees in the database.") + " " + e.getMessage());
 		}
 
 		return numberOfAttendees;
@@ -1522,7 +1522,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot load any CSV profile from the database.") + " " + e.getMessage());
+			throw new DataException(translate("Cannot load any CSV profile from the database.") + " " + e.getMessage());
 		}
 
 		return profiles;
@@ -1589,7 +1589,7 @@ public class ApplicationData extends Observable {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot load the requested CSV profile.") + " [NAME = " + name + "] " + e.getMessage());
+					translate("Cannot load the requested CSV profile.") + " [NAME = " + name + "] " + e.getMessage());
 		}
 
 		return profile;
@@ -1665,7 +1665,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot remove the CSV profile.") + " [NAME = " + name + "] " + e.getMessage());
+			throw new DataException(translate("Cannot remove the CSV profile.") + " [NAME = " + name + "] " + e.getMessage());
 		}
 	}
 
@@ -1712,7 +1712,7 @@ public class ApplicationData extends Observable {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the number of catalogs in the library.") + " " + e.getMessage());
+			throw new DataException(translate("Cannot get the number of catalogs in the library.") + " " + e.getMessage());
 		}
 
 		return numberOfCSVProfiles;

--- a/src/org/revager/app/model/Data.java
+++ b/src/org/revager/app/model/Data.java
@@ -233,20 +233,20 @@ public class Data {
 	 *            the string to translate
 	 * @return translated string or the id
 	 */
-	public static String _(String id) {
+	public static String translate(String id) {
 		/*
 		 * Some special handling of the roles
 		 */
 		if (id.equals(Role.MODERATOR.toString())) {
-			return _("Moderator");
+			return translate("Moderator");
 		} else if (id.equals(Role.AUTHOR.toString())) {
-			return _("Author");
+			return translate("Author");
 		} else if (id.equals(Role.CUSTOMER.toString())) {
-			return _("Customer");
+			return translate("Customer");
 		} else if (id.equals(Role.REVIEWER.toString())) {
-			return _("Reviewer");
+			return translate("Reviewer");
 		} else if (id.equals(Role.SCRIBE.toString())) {
-			return _("Scribe");
+			return translate("Scribe");
 		}
 
 		try {
@@ -269,19 +269,19 @@ public class Data {
 		List<String> list = new ArrayList<String>();
 
 		list.add("Not rated");
-		_("Not rated");
+		translate("Not rated");
 
 		list.add("Critical error");
-		_("Critical error");
+		translate("Critical error");
 
 		list.add("Main error");
-		_("Main error");
+		translate("Main error");
 
 		list.add("Minor error");
-		_("Minor error");
+		translate("Minor error");
 
 		list.add("Good");
-		_("Good");
+		translate("Good");
 
 		return list;
 	}
@@ -295,7 +295,7 @@ public class Data {
 		List<String> list = new ArrayList<String>();
 
 		for (String sev : getDefLangSeverities()) {
-			list.add(_(sev));
+			list.add(translate(sev));
 		}
 
 		return list;
@@ -312,7 +312,7 @@ public class Data {
 	 */
 	public static String getDefLangSeverity(String severity) {
 		for (String sev : getDefLangSeverities()) {
-			if (severity.equals(_(sev))) {
+			if (severity.equals(translate(sev))) {
 				return sev;
 			}
 		}
@@ -329,22 +329,22 @@ public class Data {
 		List<String> list = new ArrayList<String>();
 
 		list.add("Accepted");
-		_("Accepted");
+		translate("Accepted");
 
 		list.add("Accepted (changes required)");
-		_("Accepted (changes required)");
+		translate("Accepted (changes required)");
 
 		list.add("Not accepted");
-		_("Not accepted");
+		translate("Not accepted");
 
 		list.add("Not finished");
-		_("Not finished");
+		translate("Not finished");
 
 		list.add("Not finished (changes required)");
-		_("Not finished (changes required)");
+		translate("Not finished (changes required)");
 
 		list.add("Not finished (complete revision required)");
-		_("Not finished (complete revision required)");
+		translate("Not finished (complete revision required)");
 
 		return list;
 	}
@@ -358,7 +358,7 @@ public class Data {
 		List<String> list = new ArrayList<String>();
 
 		for (String rec : getDefLangRecommendations()) {
-			list.add(_(rec));
+			list.add(translate(rec));
 		}
 
 		return list;
@@ -375,7 +375,7 @@ public class Data {
 	 */
 	public static String getDefLangRecommendation(String recommendation) {
 		for (String rec : getDefLangRecommendations()) {
-			if (recommendation.equals(_(rec))) {
+			if (recommendation.equals(translate(rec))) {
 				return rec;
 			}
 		}
@@ -389,7 +389,7 @@ public class Data {
 	 * @return the default invitation text
 	 */
 	public static String getDefLangInvitationText() {
-		_("You are invited to the review meeting. Please consider the information which are part of this document.");
+		translate("You are invited to the review meeting. Please consider the information which are part of this document.");
 
 		return "You are invited to the review meeting. Please consider the information which are part of this document.";
 	}

--- a/src/org/revager/app/model/HelpDataOrig.java
+++ b/src/org/revager/app/model/HelpDataOrig.java
@@ -18,7 +18,7 @@
  */
 package org.revager.app.model;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -152,7 +152,7 @@ public class HelpDataOrig {
 			 * Not part of unit testing because this exception only is thrown if
 			 * an internal error occurs which cannot be provoked.
 			 */
-			throw new DataException(_("Cannot load help information."));
+			throw new DataException(translate("Cannot load help information."));
 		}
 
 		/*
@@ -181,14 +181,14 @@ public class HelpDataOrig {
 					 * Not part of unit testing because normally you don't have
 					 * any chapters without a title.
 					 */
-					helpChaptersTitle[i] = _("<no title>");
+					helpChaptersTitle[i] = translate("<no title>");
 				}
 			} catch (Exception e) {
 				/*
 				 * Not part of unit testing because this exception only is
 				 * thrown if an internal error occurs which cannot be provoked.
 				 */
-				throw new DataException(_("Cannot load help information."));
+				throw new DataException(translate("Cannot load help information."));
 			}
 
 		}
@@ -274,7 +274,7 @@ public class HelpDataOrig {
 		}
 
 		if (title == null) {
-			throw new DataException(_("Cannot find requested help chapter.") + " [CHAPTER = " + chapter + "]");
+			throw new DataException(translate("Cannot find requested help chapter.") + " [CHAPTER = " + chapter + "]");
 		}
 
 		return title;
@@ -305,7 +305,7 @@ public class HelpDataOrig {
 		}
 
 		if (htmlCode == null) {
-			throw new DataException(_("Cannot find requested help chapter.") + " [CHAPTER = " + chapter + "]");
+			throw new DataException(translate("Cannot find requested help chapter.") + " [CHAPTER = " + chapter + "]");
 		}
 
 		return htmlCode;

--- a/src/org/revager/app/model/appdata/AppAspect.java
+++ b/src/org/revager/app/model/appdata/AppAspect.java
@@ -18,7 +18,7 @@
  */
 package org.revager.app.model.appdata;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -139,7 +139,7 @@ public class AppAspect {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot add new aspect.") + " [DIRECTIVE = " + directive + "] " + e.getMessage());
+			throw new DataException(translate("Cannot add new aspect.") + " [DIRECTIVE = " + directive + "] " + e.getMessage());
 		}
 	}
 
@@ -215,7 +215,7 @@ public class AppAspect {
 			conn.close();
 		} catch (Exception e) {
 			throw new DataException(
-					_("Cannot read directive of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
+					translate("Cannot read directive of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
 		}
 
 		return directive;
@@ -250,7 +250,7 @@ public class AppAspect {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot store directive of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
+					translate("Cannot store directive of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
 		}
 	}
 
@@ -286,7 +286,7 @@ public class AppAspect {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot read description of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
+					translate("Cannot read description of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
 		}
 
 		return description;
@@ -321,7 +321,7 @@ public class AppAspect {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot store description of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
+					translate("Cannot store description of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
 		}
 	}
 
@@ -394,7 +394,7 @@ public class AppAspect {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot read category of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
+					translate("Cannot read category of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
 		}
 
 		return category;
@@ -459,7 +459,7 @@ public class AppAspect {
 				 * thrown if there occurs an internal error.
 				 */
 				throw new DataException(
-						_("Cannot store category of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
+						translate("Cannot store category of the aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
 			}
 		}
 	}
@@ -522,7 +522,7 @@ public class AppAspect {
 				 * thrown if there occurs an internal error.
 				 */
 				throw new DataException(
-						_("Cannot move selected aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
+						translate("Cannot move selected aspect.") + " [ASPECT_ID = " + this.id + "] " + e.getMessage());
 			}
 		}
 	}
@@ -602,7 +602,7 @@ public class AppAspect {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get sorting position of the aspect.") + " [ASPECT_ID = " + this.id + "] "
+			throw new DataException(translate("Cannot get sorting position of the aspect.") + " [ASPECT_ID = " + this.id + "] "
 					+ e.getMessage());
 		}
 
@@ -644,7 +644,7 @@ public class AppAspect {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get sorting position of the aspect.") + " [ASPECT_ID = " + this.id + "] "
+			throw new DataException(translate("Cannot get sorting position of the aspect.") + " [ASPECT_ID = " + this.id + "] "
 					+ e.getMessage());
 		}
 
@@ -686,7 +686,7 @@ public class AppAspect {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get sorting position of the aspect.") + " [ASPECT_ID = " + this.id + "] "
+			throw new DataException(translate("Cannot get sorting position of the aspect.") + " [ASPECT_ID = " + this.id + "] "
 					+ e.getMessage());
 		}
 

--- a/src/org/revager/app/model/appdata/AppAttendee.java
+++ b/src/org/revager/app/model/appdata/AppAttendee.java
@@ -18,7 +18,7 @@
  */
 package org.revager.app.model.appdata;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -49,7 +49,7 @@ public class AppAttendee {
 	 * This is exception is thrown if an attendee could not be found.
 	 */
 	private DataException notFoundExc = new DataException(
-			_("Attendee does not exist!") + " [NAME = " + this.name + ", CONTACT = " + this.contact + "]");
+			translate("Attendee does not exist!") + " [NAME = " + this.name + ", CONTACT = " + this.contact + "]");
 
 	/**
 	 * Internally used contructor to create a new instance of this class by the
@@ -174,7 +174,7 @@ public class AppAttendee {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot add or get attendee.") + " [NAME = " + name + "] " + e.getMessage());
+			throw new DataException(translate("Cannot add or get attendee.") + " [NAME = " + name + "] " + e.getMessage());
 		}
 
 		return new AppAttendee(name, contact);
@@ -309,7 +309,7 @@ public class AppAttendee {
 			}
 		} catch (Exception e) {
 			throw new DataException(
-					_("Cannot store attendee! There may be an attendee with the given name and contact information already existing.")
+					translate("Cannot store attendee! There may be an attendee with the given name and contact information already existing.")
 							+ " [NAME = " + this.name + ", CONTACT = " + this.contact + "] " + e.getMessage());
 		}
 	}
@@ -348,7 +348,7 @@ public class AppAttendee {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get strengths of the selected attendee.") + " [NAME = " + this.name + "] "
+			throw new DataException(translate("Cannot get strengths of the selected attendee.") + " [NAME = " + this.name + "] "
 					+ e.getMessage());
 		}
 
@@ -392,7 +392,7 @@ public class AppAttendee {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot detect wether the given category is a strength of the attendee or not.")
+			throw new DataException(translate("Cannot detect wether the given category is a strength of the attendee or not.")
 					+ " [NAME = " + this.name + "] " + e.getMessage());
 		}
 
@@ -436,7 +436,7 @@ public class AppAttendee {
 				 * thrown if there occurs an internal error.
 				 */
 				throw new DataException(
-						_("Cannot assign strength to the attendee.") + " [NAME = " + this.name + "] " + e.getMessage());
+						translate("Cannot assign strength to the attendee.") + " [NAME = " + this.name + "] " + e.getMessage());
 			}
 		}
 	}
@@ -520,7 +520,7 @@ public class AppAttendee {
 				 * thrown if there occurs an internal error.
 				 */
 				throw new DataException(
-						_("Cannot remove strength of the attendee.") + " [NAME = " + this.name + "] " + e.getMessage());
+						translate("Cannot remove strength of the attendee.") + " [NAME = " + this.name + "] " + e.getMessage());
 			}
 		}
 	}

--- a/src/org/revager/app/model/appdata/AppCSVProfile.java
+++ b/src/org/revager/app/model/appdata/AppCSVProfile.java
@@ -18,7 +18,7 @@
  */
 package org.revager.app.model.appdata;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -45,7 +45,7 @@ public class AppCSVProfile {
 	 * This exception is thrown if the CSV profile could not be found.
 	 */
 	private DataException notFoundExc = new DataException(
-			_("CSV profile does not exist!") + " [NAME = " + this.name + "]");
+			translate("CSV profile does not exist!") + " [NAME = " + this.name + "]");
 
 	/**
 	 * Internally used constructor to create a new instance of this class.
@@ -152,7 +152,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot add or get CSV profile.") + " [NAME = " + name + "] " + e.getMessage());
+			throw new DataException(translate("Cannot add or get CSV profile.") + " [NAME = " + name + "] " + e.getMessage());
 		}
 
 		return new AppCSVProfile(name);
@@ -222,7 +222,7 @@ public class AppCSVProfile {
 				}
 			} catch (Exception e) {
 				throw new DataException(
-						_("Cannot store name of the CSV profile.") + " [NAME = " + this.name + "] " + e.getMessage());
+						translate("Cannot store name of the CSV profile.") + " [NAME = " + this.name + "] " + e.getMessage());
 			}
 		}
 	}
@@ -261,7 +261,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get column order of the selected CSV profile.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot get column order of the selected CSV profile.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 
@@ -324,7 +324,7 @@ public class AppCSVProfile {
 				throw new DataException();
 			}
 		} catch (Exception e) {
-			throw new DataException(_("Cannot set column order of the selected CSV profile.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot set column order of the selected CSV profile.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 	}
@@ -362,7 +362,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the requested property of the selected CSV profile.") + " [NAME = "
+			throw new DataException(translate("Cannot get the requested property of the selected CSV profile.") + " [NAME = "
 					+ this.name + "] " + e.getMessage());
 		}
 
@@ -402,7 +402,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot store property of the selected CSV profile.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot store property of the selected CSV profile.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 	}
@@ -439,7 +439,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the requested property of the selected CSV profile.") + " [NAME = "
+			throw new DataException(translate("Cannot get the requested property of the selected CSV profile.") + " [NAME = "
 					+ this.name + "] " + e.getMessage());
 		}
 
@@ -479,7 +479,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot store property of the selected CSV profile.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot store property of the selected CSV profile.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 	}
@@ -522,7 +522,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the requested property of the selected CSV profile.") + " [NAME = "
+			throw new DataException(translate("Cannot get the requested property of the selected CSV profile.") + " [NAME = "
 					+ this.name + "] " + e.getMessage());
 		}
 
@@ -565,7 +565,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the requested property of the selected CSV profile.") + " [NAME = "
+			throw new DataException(translate("Cannot get the requested property of the selected CSV profile.") + " [NAME = "
 					+ this.name + "] " + e.getMessage());
 		}
 
@@ -616,7 +616,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot store property of the selected CSV profile.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot store property of the selected CSV profile.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 	}
@@ -657,7 +657,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot store property of the selected CSV profile.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot store property of the selected CSV profile.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 	}
@@ -696,7 +696,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the requested property of the selected CSV profile.") + " [NAME = "
+			throw new DataException(translate("Cannot get the requested property of the selected CSV profile.") + " [NAME = "
 					+ this.name + "] " + e.getMessage());
 		}
 
@@ -771,7 +771,7 @@ public class AppCSVProfile {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot store property of the selected CSV profile.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot store property of the selected CSV profile.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 	}

--- a/src/org/revager/app/model/appdata/AppCatalog.java
+++ b/src/org/revager/app/model/appdata/AppCatalog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.app.model.appdata;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -43,7 +43,7 @@ public class AppCatalog {
 	/**
 	 * This exception is thrown if the catalog could not be found.
 	 */
-	private DataException notFoundExc = new DataException(_("Catalog doesn't exists!") + " [NAME = " + this.name + "]");
+	private DataException notFoundExc = new DataException(translate("Catalog doesn't exists!") + " [NAME = " + this.name + "]");
 
 	/**
 	 * Internally used contructor.
@@ -145,7 +145,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot add or get catalog.") + " [NAME = " + name + "] " + e.getMessage());
+			throw new DataException(translate("Cannot add or get catalog.") + " [NAME = " + name + "] " + e.getMessage());
 		}
 
 		return new AppCatalog(name);
@@ -232,7 +232,7 @@ public class AppCatalog {
 					throw new DataException();
 				}
 			} catch (Exception e) {
-				throw new DataException(_("Cannot set catalog name.") + " [NAME = " + this.name + "]");
+				throw new DataException(translate("Cannot set catalog name.") + " [NAME = " + this.name + "]");
 			}
 		}
 	}
@@ -364,7 +364,7 @@ public class AppCatalog {
 				 * thrown if there occurs an internal error.
 				 */
 				throw new DataException(
-						_("Cannot move the selected catalog.") + " [NAME = " + this.name + "] " + e.getMessage());
+						translate("Cannot move the selected catalog.") + " [NAME = " + this.name + "] " + e.getMessage());
 			}
 		}
 	}
@@ -444,7 +444,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the sorting position of the catalogs.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot get the sorting position of the catalogs.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 
@@ -484,7 +484,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the sorting position of the catalogs.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot get the sorting position of the catalogs.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 
@@ -524,7 +524,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get the sorting position of the catalogs.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot get the sorting position of the catalogs.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 
@@ -568,7 +568,7 @@ public class AppCatalog {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot get sorting position of the category.") + " [NAME = " + category + "] " + e.getMessage());
+					translate("Cannot get sorting position of the category.") + " [NAME = " + category + "] " + e.getMessage());
 		}
 
 		return sortPos;
@@ -612,7 +612,7 @@ public class AppCatalog {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot get sorting position of the category.") + " [NAME = " + category + "] " + e.getMessage());
+					translate("Cannot get sorting position of the category.") + " [NAME = " + category + "] " + e.getMessage());
 		}
 
 		return sortPos;
@@ -656,7 +656,7 @@ public class AppCatalog {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot get sorting position of the category.") + " [NAME = " + category + "] " + e.getMessage());
+					translate("Cannot get sorting position of the category.") + " [NAME = " + category + "] " + e.getMessage());
 		}
 
 		return sortPos;
@@ -695,7 +695,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get first sorting position of the categories.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot get first sorting position of the categories.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 
@@ -735,7 +735,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get last sorting position of the categories.") + " [NAME = " + this.name
+			throw new DataException(translate("Cannot get last sorting position of the categories.") + " [NAME = " + this.name
 					+ "] " + e.getMessage());
 		}
 
@@ -806,7 +806,7 @@ public class AppCatalog {
 				 * thrown if there occurs an internal error.
 				 */
 				throw new DataException(
-						_("Cannot move the selected category.") + " [NAME = " + category + "] " + e.getMessage());
+						translate("Cannot move the selected category.") + " [NAME = " + category + "] " + e.getMessage());
 			}
 		}
 	}
@@ -899,7 +899,7 @@ public class AppCatalog {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot get the number of categories.") + " [NAME = " + this.name + "] " + e.getMessage());
+					translate("Cannot get the number of categories.") + " [NAME = " + this.name + "] " + e.getMessage());
 		}
 
 		return numberOfCategories;
@@ -937,7 +937,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get category of the selected catalog.") + " [NAME = " + this.name + "] "
+			throw new DataException(translate("Cannot get category of the selected catalog.") + " [NAME = " + this.name + "] "
 					+ e.getMessage());
 		}
 
@@ -1004,7 +1004,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot detect wether the given category exists or not.") + " [NAME = " + name
+			throw new DataException(translate("Cannot detect wether the given category exists or not.") + " [NAME = " + name
 					+ "] " + e.getMessage());
 		}
 
@@ -1066,7 +1066,7 @@ public class AppCatalog {
 				throw new DataException();
 			}
 		} catch (Exception e) {
-			throw new DataException(_("Cannot change category.") + " [NAME = " + oldName + "] " + e.getMessage());
+			throw new DataException(translate("Cannot change category.") + " [NAME = " + oldName + "] " + e.getMessage());
 		}
 	}
 
@@ -1107,7 +1107,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get first sorting position of the aspects.") + " [NAME = " + category
+			throw new DataException(translate("Cannot get first sorting position of the aspects.") + " [NAME = " + category
 					+ "] " + e.getMessage());
 		}
 
@@ -1151,7 +1151,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get last sorting position of the aspects.") + " [NAME = " + category
+			throw new DataException(translate("Cannot get last sorting position of the aspects.") + " [NAME = " + category
 					+ "] " + e.getMessage());
 		}
 
@@ -1201,7 +1201,7 @@ public class AppCatalog {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot get the number of aspects.") + " [NAME = " + this.name + "] " + e.getMessage());
+					translate("Cannot get the number of aspects.") + " [NAME = " + this.name + "] " + e.getMessage());
 		}
 
 		return numberOfAspects;
@@ -1255,7 +1255,7 @@ public class AppCatalog {
 			 * Not part of the unit testing, because this exception is only
 			 * thrown if there occurs an internal error.
 			 */
-			throw new DataException(_("Cannot get aspects of the selected catalog / category.") + " [NAME = "
+			throw new DataException(translate("Cannot get aspects of the selected catalog / category.") + " [NAME = "
 					+ this.name + "] " + e.getMessage());
 		}
 
@@ -1368,7 +1368,7 @@ public class AppCatalog {
 			 * thrown if there occurs an internal error.
 			 */
 			throw new DataException(
-					_("Cannot remove aspect.") + " [ASPECT_ID = " + aspect.getId() + "] " + e.getMessage());
+					translate("Cannot remove aspect.") + " [ASPECT_ID = " + aspect.getId() + "] " + e.getMessage());
 		}
 	}
 

--- a/src/org/revager/export/FindingsCSVExporter.java
+++ b/src/org/revager/export/FindingsCSVExporter.java
@@ -18,7 +18,7 @@
  */
 package org.revager.export;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.text.MessageFormat;
 import java.util.HashMap;
@@ -147,7 +147,7 @@ public class FindingsCSVExporter extends CSVExporter {
 			for (AppCSVColumnName col : columnOrder) {
 				switch (col) {
 				case DESCRIPTION:
-					csvLine[index] = f.getDescription() + " (" + _("Review Findings") + " " + f.getId() + ")";
+					csvLine[index] = f.getDescription() + " (" + translate("Review Findings") + " " + f.getId() + ")";
 					break;
 
 				case REFERENCE:
@@ -163,7 +163,7 @@ public class FindingsCSVExporter extends CSVExporter {
 					}
 
 					String references = MessageFormat.format(
-							_("Finding {0} of Review \"{1}\" ** Product: {2} (Version: {3}) **** {4}"),
+							translate("Finding {0} of Review \"{1}\" ** Product: {2} (Version: {3}) **** {4}"),
 							Integer.toString(f.getId()), revMgmt.getReviewName(), revMgmt.getProductName(),
 							revMgmt.getProductVersion(), refs);
 

--- a/src/org/revager/export/InvitationDirExporter.java
+++ b/src/org/revager/export/InvitationDirExporter.java
@@ -18,7 +18,7 @@
  */
 package org.revager.export;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 import java.io.IOException;
@@ -87,7 +87,7 @@ public class InvitationDirExporter {
 		this.directory = new File(dirPath);
 		this.attachProdExtRefs = attachProdExtRefs;
 
-		this.reviewInfoDoc = new File(directory, _("Review_Information.pdf"));
+		this.reviewInfoDoc = new File(directory, translate("Review_Information.pdf"));
 	}
 
 	/**
@@ -126,7 +126,7 @@ public class InvitationDirExporter {
 					 * Not part of unit testing because this exception is only
 					 * thrown if an internal error occurs.
 					 */
-					throw new ExportException(_("Cannot store invitation as directory."));
+					throw new ExportException(translate("Cannot store invitation as directory."));
 				}
 			}
 		}

--- a/src/org/revager/export/InvitationPDFExporter.java
+++ b/src/org/revager/export/InvitationPDFExporter.java
@@ -18,7 +18,7 @@
  */
 package org.revager.export;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Color;
 import java.io.File;
@@ -106,7 +106,7 @@ public class InvitationPDFExporter extends PDFExporter {
 	/**
 	 * The date formatter for times.
 	 */
-	private DateFormat sdfTime = new SimpleDateFormat(_("HH:mm"));
+	private DateFormat sdfTime = new SimpleDateFormat(translate("HH:mm"));
 
 	/**
 	 * The meeting.
@@ -131,7 +131,7 @@ public class InvitationPDFExporter extends PDFExporter {
 		String title = resiData.getReview().getName();
 
 		if (title.trim().equals("")) {
-			title = _("Review Meeting");
+			title = translate("Review Meeting");
 		}
 
 		return title;
@@ -158,7 +158,7 @@ public class InvitationPDFExporter extends PDFExporter {
 	 */
 	public InvitationPDFExporter(String filePath, Meeting meeting, Attendee attendee, boolean attachProdExtRefs)
 			throws ExportException, DataException {
-		super(filePath, _("Invitation") + " · " + getReviewTitle(),
+		super(filePath, translate("Invitation") + " · " + getReviewTitle(),
 				appData.getSetting(AppSettingKey.PDF_INVITATION_LOGO),
 				appData.getSetting(AppSettingKey.PDF_INVITATION_FOOT_TEXT));
 
@@ -242,7 +242,7 @@ public class InvitationPDFExporter extends PDFExporter {
 			PdfPCell cellRecipient = new PdfPCell();
 			cellRecipient.setBorder(0);
 			cellRecipient.setPadding(0);
-			cellRecipient.addElement(new Phrase(_("To:"), plainFontTitle));
+			cellRecipient.addElement(new Phrase(translate("To:"), plainFontTitle));
 			cellRecipient.addElement(new Phrase(attendee.getName(), boldFontTitle));
 
 			tableRecipient.addCell(cellRecipient);
@@ -264,7 +264,7 @@ public class InvitationPDFExporter extends PDFExporter {
 			/*
 			 * subject
 			 */
-			cell.addElement(new Phrase(_("Invitation for the Meeting on") + " " + meetingDate, boldItalicFontTitle));
+			cell.addElement(new Phrase(translate("Invitation for the Meeting on") + " " + meetingDate, boldItalicFontTitle));
 
 			cell.addElement(phraseStrut);
 
@@ -303,7 +303,7 @@ public class InvitationPDFExporter extends PDFExporter {
 			table.addCell(cell);
 
 			if (!meeting.getPlannedLocation().equals("")) {
-				cell = new PdfPCell(new Phrase(_("Location") + ": " + meeting.getPlannedLocation(), italicFont));
+				cell = new PdfPCell(new Phrase(translate("Location") + ": " + meeting.getPlannedLocation(), italicFont));
 				cell.setBorder(0);
 				cell.setColspan(2);
 				cell.setPadding(padding);
@@ -326,8 +326,8 @@ public class InvitationPDFExporter extends PDFExporter {
 
 			phrase = new Phrase();
 			phrase.setLeading(leading);
-			phrase.add(new Chunk(MessageFormat.format(_("You are invited as {0} to this review ({1})."),
-					_(attendee.getRole().toString()), getReviewTitle()), boldFont));
+			phrase.add(new Chunk(MessageFormat.format(translate("You are invited as {0} to this review ({1})."),
+					translate(attendee.getRole().toString()), getReviewTitle()), boldFont));
 
 			cell.addElement(phrase);
 
@@ -345,7 +345,7 @@ public class InvitationPDFExporter extends PDFExporter {
 						.format(meetMgmt.getPredecessorMeeting(meeting).getProtocol().getDate().getTime());
 
 				cell.addElement(new Phrase(
-						MessageFormat.format(_("This meeting ties up to the review meeting of {0}."), preMeetingDate),
+						MessageFormat.format(translate("This meeting ties up to the review meeting of {0}."), preMeetingDate),
 						plainFont));
 
 				cell.addElement(phraseStrut);
@@ -358,7 +358,7 @@ public class InvitationPDFExporter extends PDFExporter {
 				/*
 				 * the product of this review
 				 */
-				cell.addElement(new Phrase(_("The following product will be reviewed:"), plainFont));
+				cell.addElement(new Phrase(translate("The following product will be reviewed:"), plainFont));
 				cell.addElement(phraseStrut);
 
 				table.addCell(cell);
@@ -384,7 +384,7 @@ public class InvitationPDFExporter extends PDFExporter {
 				 */
 				if (!Data.getInstance().getResiData().getReview().getProduct().getVersion().trim().equals("")) {
 					Phrase phrVersion = new Phrase(
-							_("Product Version") + ": "
+							translate("Product Version") + ": "
 									+ Data.getInstance().getResiData().getReview().getProduct().getVersion(),
 							italicFont);
 					phrVersion.setLeading(leading);
@@ -445,7 +445,7 @@ public class InvitationPDFExporter extends PDFExporter {
 			for (File ref : Application.getInstance().getReviewMgmt().getExtProdReferences()) {
 				Phrase phraseRef = new Phrase();
 				phraseRef.add(new Chunk(ref.getName(), italicFontSmall));
-				phraseRef.add(new Chunk(" (" + _("File Attachment") + ")", italicFontSmall));
+				phraseRef.add(new Chunk(" (" + translate("File Attachment") + ")", italicFontSmall));
 				phraseRef.setFont(plainFont);
 				phraseRef.setLeading(leading);
 
@@ -483,7 +483,7 @@ public class InvitationPDFExporter extends PDFExporter {
 
 			if (attendee.getAspects() != null) {
 				phrase.add(new Chunk(
-						_("Please prepare for the review meeting by checking the product for the aspects which are associated to you.")
+						translate("Please prepare for the review meeting by checking the product for the aspects which are associated to you.")
 								+ " ",
 						plainFont));
 			}
@@ -497,11 +497,11 @@ public class InvitationPDFExporter extends PDFExporter {
 
 			if (moderators.size() == 1 && attendee.getRole() != Role.MODERATOR) {
 				phrase.add(new Chunk(
-						_("Please do not hesitate to contact the review moderator if you have any questions:") + " ",
+						translate("Please do not hesitate to contact the review moderator if you have any questions:") + " ",
 						plainFont));
 			} else if (moderators.size() > 1 && attendee.getRole() != Role.MODERATOR) {
 				phrase.add(new Chunk(
-						_("Please do not hesitate to contact one of the review moderators if you have any questions:")
+						translate("Please do not hesitate to contact one of the review moderators if you have any questions:")
 								+ " ",
 						plainFont));
 			}
@@ -527,7 +527,7 @@ public class InvitationPDFExporter extends PDFExporter {
 			 * Not part of unit testing because this exception is only thrown if
 			 * an internal error occurs.
 			 */
-			throw new ExportException(_("Cannot generate front page of the PDF document."));
+			throw new ExportException(translate("Cannot generate front page of the PDF document."));
 		}
 	}
 
@@ -676,7 +676,7 @@ public class InvitationPDFExporter extends PDFExporter {
 			 * Not part of unit testing because this exception is only thrown if
 			 * an internal error occurs.
 			 */
-			throw new ExportException(_("Cannot put aspects into the PDF document."));
+			throw new ExportException(translate("Cannot put aspects into the PDF document."));
 		}
 	}
 
@@ -707,7 +707,7 @@ public class InvitationPDFExporter extends PDFExporter {
 				pdfDoc.newPage();
 
 				phraseAspIntro = new Phrase(
-						_("Please prepare for the review meeting by checking the product for the following aspects step by step:"),
+						translate("Please prepare for the review meeting by checking the product for the following aspects step by step:"),
 						italicFont);
 
 				cellAspIntro.addElement(phraseAspIntro);
@@ -718,7 +718,7 @@ public class InvitationPDFExporter extends PDFExporter {
 			} else if (attendee.getRole() != Role.REVIEWER) {
 				pdfDoc.newPage();
 
-				phraseAspIntro = new Phrase(_("The product will be checked for the following aspects:"), italicFont);
+				phraseAspIntro = new Phrase(translate("The product will be checked for the following aspects:"), italicFont);
 
 				cellAspIntro.addElement(phraseAspIntro);
 
@@ -733,7 +733,7 @@ public class InvitationPDFExporter extends PDFExporter {
 			 * Not part of unit testing because this exception is only thrown if
 			 * an internal error occurs.
 			 */
-			throw new ExportException(_("Cannot create invitation for the review meeting.") + "\n\n" + e.getMessage());
+			throw new ExportException(translate("Cannot create invitation for the review meeting.") + "\n\n" + e.getMessage());
 		}
 	}
 

--- a/src/org/revager/export/InvitationZIPExporter.java
+++ b/src/org/revager/export/InvitationZIPExporter.java
@@ -18,7 +18,7 @@
  */
 package org.revager.export;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,7 +53,7 @@ public class InvitationZIPExporter {
 	/**
 	 * The review info document.
 	 */
-	private static final File REVIEW_INFO_DOC = new File(WORK_DIRECTORY, _("Review_Information.pdf"));
+	private static final File REVIEW_INFO_DOC = new File(WORK_DIRECTORY, translate("Review_Information.pdf"));
 
 	/**
 	 * The meeting.
@@ -135,7 +135,7 @@ public class InvitationZIPExporter {
 			 * Not part of unit testing because this exception is only thrown if
 			 * an internal error occurs.
 			 */
-			throw new ExportException(_("Cannot store invitation as ZIP file."));
+			throw new ExportException(translate("Cannot store invitation as ZIP file."));
 		}
 	}
 }

--- a/src/org/revager/export/MeetingProtocolPDFExporter.java
+++ b/src/org/revager/export/MeetingProtocolPDFExporter.java
@@ -18,7 +18,7 @@
  */
 package org.revager.export;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import org.revager.app.model.ApplicationData;
 import org.revager.app.model.Data;
@@ -87,7 +87,7 @@ public class MeetingProtocolPDFExporter extends ProtocolPDFExporter {
 	 */
 	public MeetingProtocolPDFExporter(String filePath, Meeting meeting, boolean showSignFields,
 			boolean attachProdExtRefs, boolean attachFindExtRefs) throws ExportException, DataException {
-		super(filePath, _("List of Findings") + " · " + reviewTitle,
+		super(filePath, translate("List of Findings") + " · " + reviewTitle,
 				appData.getSetting(AppSettingKey.PDF_PROTOCOL_LOGO),
 				appData.getSetting(AppSettingKey.PDF_PROTOCOL_FOOT_TEXT));
 
@@ -121,7 +121,7 @@ public class MeetingProtocolPDFExporter extends ProtocolPDFExporter {
 			 * Not part of unit testing because this exception is only thrown if
 			 * an internal error occurs.
 			 */
-			throw new ExportException(_("Cannot create PDF document."));
+			throw new ExportException(translate("Cannot create PDF document."));
 		}
 	}
 

--- a/src/org/revager/export/PDFCellEventExtRef.java
+++ b/src/org/revager/export/PDFCellEventExtRef.java
@@ -18,7 +18,7 @@
  */
 package org.revager.export;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 import java.io.IOException;
@@ -75,7 +75,7 @@ public class PDFCellEventExtRef implements PdfPCellEvent {
 		Rectangle attachmentRect = new Rectangle(rect.getLeft() - 25, rect.getTop() - 25,
 				rect.getRight() - rect.getWidth() - 40, rect.getTop() - 10);
 
-		String fileDesc = file.getName() + " (" + _("File Attachment") + ")";
+		String fileDesc = file.getName() + " (" + translate("File Attachment") + ")";
 
 		try {
 			PdfAnnotation attachment = PdfAnnotation.createFileAttachment(writer, attachmentRect, fileDesc, null,

--- a/src/org/revager/export/PDFExporter.java
+++ b/src/org/revager/export/PDFExporter.java
@@ -18,7 +18,7 @@
  */
 package org.revager.export;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.FileOutputStream;
 
@@ -84,7 +84,7 @@ public abstract class PDFExporter {
 			 * Not part of unit testing because this exception is only thrown if
 			 * an internal error occurs.
 			 */
-			throw new ExportException(_(
+			throw new ExportException(translate(
 					"Cannot store PDF file. Either you don't have write permissions or the PDF file cannot be created."));
 		}
 

--- a/src/org/revager/export/PDFPageEventHelper.java
+++ b/src/org/revager/export/PDFPageEventHelper.java
@@ -18,7 +18,7 @@
  */
 package org.revager.export;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.text.MessageFormat;
 
@@ -284,7 +284,7 @@ public class PDFPageEventHelper extends PdfPageEventHelper {
 			PdfContentByte contentByte = writer.getDirectContent();
 			contentByte.saveState();
 
-			String text = MessageFormat.format(_("Page {0} of") + " ", writer.getPageNumber());
+			String text = MessageFormat.format(translate("Page {0} of") + " ", writer.getPageNumber());
 
 			float textSize = footBaseFont.getWidthPoint(text, footFontSize);
 			float textBase = document.bottom() - PDFTools.cmToPt(1.26f);

--- a/src/org/revager/export/ProtocolPDFExporter.java
+++ b/src/org/revager/export/ProtocolPDFExporter.java
@@ -18,7 +18,7 @@
  */
 package org.revager.export;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Color;
 import java.io.File;
@@ -83,7 +83,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 	/**
 	 * The date formatter for times.
 	 */
-	protected DateFormat sdfTime = new SimpleDateFormat(_("HH:mm"));
+	protected DateFormat sdfTime = new SimpleDateFormat(translate("HH:mm"));
 
 	/**
 	 * The cell background for tables.
@@ -122,7 +122,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 		String title = Data.getInstance().getResiData().getReview().getName();
 
 		if (title.trim().equals("")) {
-			title = _("Review");
+			title = translate("Review");
 		}
 
 		return title;
@@ -221,10 +221,10 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 			tableTitlePage.getDefaultCell().setBorder(0);
 			tableTitlePage.getDefaultCell().setPadding(0);
 
-			String protocolTitle = _("Findings List of the Review");
+			String protocolTitle = translate("Findings List of the Review");
 
 			if (meetings.size() == 1) {
-				protocolTitle = _("Findings List of the Review Meeting");
+				protocolTitle = translate("Findings List of the Review Meeting");
 			}
 
 			PdfPCell cellProtocol = new PdfPCell(new Phrase(protocolTitle, protocolFontTitle));
@@ -276,7 +276,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				if (location.trim().equals("")) {
 					location = "--";
 				}
-				cellMeeting = new PdfPCell(new Phrase(_("Location") + ": " + location, meetingFontTitle));
+				cellMeeting = new PdfPCell(new Phrase(translate("Location") + ": " + location, meetingFontTitle));
 				cellMeeting.setColspan(2);
 				cellMeeting.setHorizontalAlignment(Element.ALIGN_CENTER);
 				cellMeeting.setPadding(0);
@@ -290,13 +290,13 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 			/*
 			 * Review description and comments
 			 */
-			PdfPCell cellRevDesc = new PdfPCell(new Phrase(_("Review Description:"), boldItalicFont));
+			PdfPCell cellRevDesc = new PdfPCell(new Phrase(translate("Review Description:"), boldItalicFont));
 			cellRevDesc.setBorderWidth(0);
 			cellRevDesc.setPadding(padding);
 
 			tableTitlePage.addCell(cellRevDesc);
 
-			cellRevDesc = new PdfPCell(new Phrase(_("Review Comments"), boldFont));
+			cellRevDesc = new PdfPCell(new Phrase(translate("Review Comments"), boldFont));
 			cellRevDesc.setBorderWidth(0);
 			cellRevDesc.setPadding(padding);
 			cellRevDesc.setBackgroundColor(cellBackground);
@@ -345,7 +345,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 			tableProduct.getDefaultCell().setBorderWidth(0);
 			tableProduct.getDefaultCell().setPadding(0);
 
-			PdfPCell cellProdTitle = new PdfPCell(new Phrase(_("Reviewed Product:"), boldItalicFont));
+			PdfPCell cellProdTitle = new PdfPCell(new Phrase(translate("Reviewed Product:"), boldItalicFont));
 			cellProdTitle.setColspan(2);
 			cellProdTitle.setPadding(padding);
 			cellProdTitle.setBorder(0);
@@ -374,7 +374,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				prodName = "--";
 			}
 
-			Phrase phrName = new Phrase(_("Product Name") + ": " + prodName, plainFont);
+			Phrase phrName = new Phrase(translate("Product Name") + ": " + prodName, plainFont);
 			phrName.setLeading(leading);
 
 			PdfPCell cellName = new PdfPCell();
@@ -393,7 +393,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				prodVersion = "--";
 			}
 
-			Phrase phrVersion = new Phrase(_("Product Version") + ": " + prodVersion, plainFont);
+			Phrase phrVersion = new Phrase(translate("Product Version") + ": " + prodVersion, plainFont);
 			phrVersion.setLeading(leading);
 
 			PdfPCell cellVersion = new PdfPCell();
@@ -410,7 +410,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				/*
 				 * Table of product references
 				 */
-				PdfPCell cellRefTitle = new PdfPCell(new Phrase(_("Product References:"), boldItalicFont));
+				PdfPCell cellRefTitle = new PdfPCell(new Phrase(translate("Product References:"), boldItalicFont));
 				cellRefTitle.setBorderWidth(0);
 				cellRefTitle.setPadding(padding);
 				cellRefTitle.setPaddingTop(padding * 4);
@@ -442,7 +442,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				for (File ref : Application.getInstance().getReviewMgmt().getExtProdReferences()) {
 					Phrase phraseRef = new Phrase();
 					phraseRef.add(new Chunk(ref.getName(), plainFont));
-					phraseRef.add(new Chunk(" (" + _("File Attachment") + ")", italicFont));
+					phraseRef.add(new Chunk(" (" + translate("File Attachment") + ")", italicFont));
 					phraseRef.setFont(plainFont);
 					phraseRef.setLeading(leading);
 
@@ -487,10 +487,10 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 			tableInfos.getDefaultCell().setBorderWidth(0);
 			tableInfos.getDefaultCell().setPadding(0);
 
-			String title = _("Meeting Information:");
+			String title = translate("Meeting Information:");
 
 			if (meetings.size() > 1) {
-				title = _("Findings Lists of the Review Meetings:");
+				title = translate("Findings Lists of the Review Meetings:");
 			}
 
 			PdfPCell cellInfosTitle = new PdfPCell(new Phrase(title, boldFont));
@@ -523,8 +523,8 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 							protLoc = "--";
 						}
 
-						Phrase phraseMeet = new Phrase(_("Date") + ": " + meetingDate + "\n" + _("Time") + ": "
-								+ meetingTime + "\n" + _("Location") + ": " + protLoc, italicFont);
+						Phrase phraseMeet = new Phrase(translate("Date") + ": " + meetingDate + "\n" + translate("Time") + ": "
+								+ meetingTime + "\n" + translate("Location") + ": " + protLoc, italicFont);
 
 						Paragraph paraMeet = new Paragraph();
 						paraMeet.setLeading(leading);
@@ -559,8 +559,8 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				Duration meetDur = DatatypeFactory.newInstance()
 						.newDuration(prot.getEnd().getTimeInMillis() - prot.getStart().getTimeInMillis());
 
-				Phrase phraseMeetInfo = new Phrase(_("Duration of the meeting") + ":\n" + meetDur.getHours() + " "
-						+ _("Hour(s)") + ", " + meetDur.getMinutes() + " " + _("Minute(s)"), italicFont);
+				Phrase phraseMeetInfo = new Phrase(translate("Duration of the meeting") + ":\n" + meetDur.getHours() + " "
+						+ translate("Hour(s)") + ", " + meetDur.getMinutes() + " " + translate("Minute(s)"), italicFont);
 				phraseMeetInfo.setLeading(leading);
 
 				PdfPCell cellMeetInfo = new PdfPCell();
@@ -575,7 +575,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				/*
 				 * meeting number of findings
 				 */
-				phraseMeetInfo = new Phrase(_("Number of findings") + ": " + prot.getFindings().size(), italicFont);
+				phraseMeetInfo = new Phrase(translate("Number of findings") + ": " + prot.getFindings().size(), italicFont);
 				phraseMeetInfo.setLeading(leading);
 
 				cellMeetInfo = new PdfPCell();
@@ -590,7 +590,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				/*
 				 * meeting number of attendees
 				 */
-				phraseMeetInfo = new Phrase(_("Number of attendees") + ": " + protMgmt.getAttendees(prot).size(),
+				phraseMeetInfo = new Phrase(translate("Number of attendees") + ": " + protMgmt.getAttendees(prot).size(),
 						italicFont);
 				phraseMeetInfo.setLeading(leading);
 
@@ -629,7 +629,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 			 */
 			tableRevInfo.addCell(createVerticalStrut(PDFTools.cmToPt(0.5f), 2));
 
-			PdfPCell cellImpr = new PdfPCell(new Phrase(_("General impressions of the product:"), boldFont));
+			PdfPCell cellImpr = new PdfPCell(new Phrase(translate("General impressions of the product:"), boldFont));
 			cellImpr.setBorderWidth(0);
 			cellImpr.setPadding(padding);
 			cellImpr.setBorderColor(verticalBorderColor);
@@ -637,7 +637,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 
 			tableRevInfo.addCell(cellImpr);
 
-			PdfPCell cellReco = new PdfPCell(new Phrase(_("Final recommendation for the product:"), boldFont));
+			PdfPCell cellReco = new PdfPCell(new Phrase(translate("Final recommendation for the product:"), boldFont));
 			cellReco.setBorderWidth(0);
 			cellReco.setPadding(padding);
 			cellReco.setBorderColor(verticalBorderColor);
@@ -696,7 +696,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 
 			Phrase phrSeverities = new Phrase();
 			phrSeverities
-					.add(new Chunk(_("The severities of the findings in this review (descending order of importance):"),
+					.add(new Chunk(translate("The severities of the findings in this review (descending order of importance):"),
 							italicFontSmall));
 			phrSeverities.add(new Chunk(" " + severities, boldItalicFontSmall));
 			phrSeverities.setLeading(leading);
@@ -714,7 +714,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 			if (meetings.size() > 1) {
 				Phrase phrRevStat = new Phrase(
 						MessageFormat.format(
-								_("This review consists of {0} attendees, {1} findings, {2} meetings and {3} aspects."),
+								translate("This review consists of {0} attendees, {1} findings, {2} meetings and {3} aspects."),
 								Application.getInstance().getReviewMgmt().getNumberOfAttendees(),
 								Application.getInstance().getReviewMgmt().getNumberOfFindings(),
 								Application.getInstance().getReviewMgmt().getNumberOfMeetings(),
@@ -737,7 +737,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 			 */
 			String creationDate = sdfDate.format(new Date().getTime());
 
-			Phrase phrCreationDate = new Phrase(_("This finding has been created with RevAger on") + " " + creationDate,
+			Phrase phrCreationDate = new Phrase(translate("This finding has been created with RevAger on") + " " + creationDate,
 					plainFontSmall);
 			phrCreationDate.setLeading(leading);
 			PdfPCell cellCrDate = new PdfPCell();
@@ -768,7 +768,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 			 * Not part of unit testing because this exception is only thrown if
 			 * an internal error occurs.
 			 */
-			throw new ExportException(_("Cannot generate front page of the PDF document."));
+			throw new ExportException(translate("Cannot generate front page of the PDF document."));
 		}
 	}
 
@@ -827,7 +827,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 						+ sdfTime.format(protocol.getEnd().getTime()) + " ["
 						+ protocol.getEnd().getTimeZone().getDisplayName() + "]";
 
-				Anchor anchorTitle = new Anchor(_("Review Meeting on") + " " + meetingDate, boldFontTitle);
+				Anchor anchorTitle = new Anchor(translate("Review Meeting on") + " " + meetingDate, boldFontTitle);
 				anchorTitle.setName(
 						Long.toString(protocol.getDate().getTimeInMillis() + protocol.getStart().getTimeInMillis()));
 
@@ -856,7 +856,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 					location = "--";
 				}
 
-				PdfPCell cellLocation = new PdfPCell(new Phrase(_("Location") + ": " + location, italicFontTitle));
+				PdfPCell cellLocation = new PdfPCell(new Phrase(translate("Location") + ": " + location, italicFontTitle));
 				cellLocation.setColspan(2);
 				cellLocation.setHorizontalAlignment(Element.ALIGN_CENTER);
 				cellLocation.setPadding(0);
@@ -888,12 +888,12 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				if (plannedDateEqualsProtocolDate && plannedStartEqualsProtocolStart && plannedEndEqualsProtocolEnd
 						&& plannedLocationEqualsProtocolLocation) {
 					cellPlanned = new PdfPCell(
-							new Phrase(_("The meeting took place as it has been planned."), plainFont));
+							new Phrase(translate("The meeting took place as it has been planned."), plainFont));
 				} else {
 					cellPlanned = new PdfPCell();
 
 					cellPlanned.addElement(new Phrase(
-							_("The meeting didn't take place as it has been planned. The meeting was planned:"),
+							translate("The meeting didn't take place as it has been planned. The meeting was planned:"),
 							plainFont));
 
 					/*
@@ -905,7 +905,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 							+ sdfTime.format(meeting.getPlannedEnd().getTime()) + " ["
 							+ meeting.getPlannedEnd().getTimeZone().getDisplayName() + "]";
 
-					Phrase phrasePlanned = new Phrase(plannedDate + " (" + plannedTime + "); " + _("Location") + ": "
+					Phrase phrasePlanned = new Phrase(plannedDate + " (" + plannedTime + "); " + translate("Location") + ": "
 							+ meeting.getPlannedLocation(), italicFont);
 
 					cellPlanned.addElement(phrasePlanned);
@@ -921,7 +921,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				/*
 				 * Comments of the meeting and protocol
 				 */
-				Phrase phraseComments = new Phrase(_("Comments on the Meeting:"), boldFont);
+				Phrase phraseComments = new Phrase(translate("Comments on the Meeting:"), boldFont);
 				PdfPCell cellComments = new PdfPCell(phraseComments);
 				cellComments.setBorderWidth(0);
 				cellComments.setPadding(padding);
@@ -930,7 +930,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 
 				tableMeeting.addCell(cellComments);
 
-				phraseComments = new Phrase(_("Comments on the Findings List:"), boldFont);
+				phraseComments = new Phrase(translate("Comments on the Findings List:"), boldFont);
 				cellComments = new PdfPCell(phraseComments);
 				cellComments.setBorderWidth(0);
 				cellComments.setPadding(padding);
@@ -982,8 +982,8 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				 * Write attendees
 				 */
 				if (protMgmt.getAttendees(protocol).size() > 0) {
-					PdfPCell cellAtt = new PdfPCell(new Phrase(_("The following attendees participated") + " ("
-							+ protMgmt.getAttendees(protocol).size() + " " + _("attendees") + "):", boldItalicFont));
+					PdfPCell cellAtt = new PdfPCell(new Phrase(translate("The following attendees participated") + " ("
+							+ protMgmt.getAttendees(protocol).size() + " " + translate("attendees") + "):", boldItalicFont));
 					cellAtt.setColspan(2);
 					cellAtt.setPadding(0);
 					cellAtt.setBorderWidth(0);
@@ -1022,8 +1022,8 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				tableFindIntro.setWidthPercentage(100);
 
 				Phrase phraseFindIntro = new Phrase(
-						_("The following findings were recorded by the participating reviewers") + " ("
-								+ findMgmt.getNumberOfFindings(protocol) + " " + _("findings") + "): ",
+						translate("The following findings were recorded by the participating reviewers") + " ("
+								+ findMgmt.getNumberOfFindings(protocol) + " " + translate("findings") + "): ",
 						boldItalicFont);
 				phraseFindIntro.setLeading(leading);
 
@@ -1043,7 +1043,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				 * Not part of unit testing because this exception is only
 				 * thrown if an internal error occurs.
 				 */
-				throw new ExportException(_("Cannot put the selected review meeting in the PDF document."));
+				throw new ExportException(translate("Cannot put the selected review meeting in the PDF document."));
 			}
 		}
 	}
@@ -1182,7 +1182,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 
 						cell.addElement(phraseStrut);
 
-						cell.addElement(new Phrase(_("Assigned aspects:") + " ", aspectsTitleFont));
+						cell.addElement(new Phrase(translate("Assigned aspects:") + " ", aspectsTitleFont));
 
 						Phrase phraseAspects = new Phrase();
 						phraseAspects.setLeading(leading);
@@ -1211,7 +1211,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 					if (prepTime != null && showAttendeesPrepTime) {
 						cell.addElement(phraseStrut);
 
-						cell.addElement(new Phrase(_("Preparation time:") + " ", aspectsTitleFont));
+						cell.addElement(new Phrase(translate("Preparation time:") + " ", aspectsTitleFont));
 
 						Phrase phrasePrepTime = new Phrase();
 						phrasePrepTime.setLeading(leading);
@@ -1221,19 +1221,19 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 						String separator = "";
 
 						if (prepTime.getDays() > 0) {
-							prep = prep + prepTime.getDays() + " " + _("Day(s)");
+							prep = prep + prepTime.getDays() + " " + translate("Day(s)");
 
 							separator = ", ";
 						}
 
 						if (prepTime.getHours() > 0) {
-							prep = prep + separator + prepTime.getHours() + " " + _("Hour(s)");
+							prep = prep + separator + prepTime.getHours() + " " + translate("Hour(s)");
 
 							separator = ", ";
 						}
 
 						if (prepTime.getMinutes() >= 0) {
-							prep = prep + separator + prepTime.getMinutes() + " " + _("Minute(s)");
+							prep = prep + separator + prepTime.getMinutes() + " " + translate("Minute(s)");
 
 							separator = ", ";
 						}
@@ -1254,7 +1254,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 
 						cell.addElement(new Phrase("________________________________________", aspectsFont));
 
-						cell.addElement(new Phrase(_("Date, Signature") + " (" + att.getName() + ")", aspectsFont));
+						cell.addElement(new Phrase(translate("Date, Signature") + " (" + att.getName() + ")", aspectsFont));
 					}
 
 					tableAttendee.addCell(cell);
@@ -1262,7 +1262,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 					/*
 					 * role of the attendee
 					 */
-					cell = new PdfPCell(new Phrase(_(att.getRole().toString()), roleFont));
+					cell = new PdfPCell(new Phrase(translate(att.getRole().toString()), roleFont));
 					cell.setBorderWidth(0);
 					cell.setPadding(padding * 0.4f);
 					cell.setPaddingTop(padding * 1.1f);
@@ -1306,7 +1306,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 			 * Not part of unit testing because this exception is only thrown if
 			 * an internal error occurs.
 			 */
-			throw new ExportException(_("Cannot put attendees into the PDF document."));
+			throw new ExportException(translate("Cannot put attendees into the PDF document."));
 		}
 	}
 
@@ -1365,7 +1365,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 				/*
 				 * Print title of the finding
 				 */
-				Phrase phraseTitle = new Phrase(_("Finding") + " " + f.getId(), boldFontTitle);
+				Phrase phraseTitle = new Phrase(translate("Finding") + " " + f.getId(), boldFontTitle);
 
 				PdfPCell cellTitle = new PdfPCell(phraseTitle);
 				cellTitle.setBackgroundColor(bgColorTitle);
@@ -1439,7 +1439,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 					PdfPTable tableRefs = new PdfPTable(new float[] { 0.04f, 0.96f });
 					tableRefs.setWidthPercentage(100);
 
-					PdfPCell cellRefTitle = new PdfPCell(new Phrase(_("References:"), boldItalicFont));
+					PdfPCell cellRefTitle = new PdfPCell(new Phrase(translate("References:"), boldItalicFont));
 					cellRefTitle.setBorderWidth(0);
 					cellRefTitle.setPadding(padding);
 					cellRefTitle.setPaddingTop(padding * 3);
@@ -1472,7 +1472,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 						for (File ref : findMgmt.getExtReferences(f)) {
 							Phrase phraseRef = new Phrase();
 							phraseRef.add(new Chunk(ref.getName(), plainFont));
-							phraseRef.add(new Chunk(" (" + _("File Attachment") + ")", italicFont));
+							phraseRef.add(new Chunk(" (" + translate("File Attachment") + ")", italicFont));
 							phraseRef.setFont(plainFont);
 							phraseRef.setLeading(leading);
 
@@ -1499,7 +1499,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 					PdfPTable tableAspects = new PdfPTable(new float[] { 0.04f, 0.96f });
 					tableAspects.setWidthPercentage(100);
 
-					PdfPCell cellAspTitle = new PdfPCell(new Phrase(_("Aspects:"), boldItalicFont));
+					PdfPCell cellAspTitle = new PdfPCell(new Phrase(translate("Aspects:"), boldItalicFont));
 					cellAspTitle.setBorderWidth(0);
 					cellAspTitle.setPadding(padding);
 					cellAspTitle.setPaddingTop(padding * 3);
@@ -1543,7 +1543,7 @@ public abstract class ProtocolPDFExporter extends PDFExporter {
 			 * Not part of unit testing because this exception is only thrown if
 			 * an internal error occurs.
 			 */
-			throw new ExportException(_("Cannot put findings into the PDF document."));
+			throw new ExportException(translate("Cannot put findings into the PDF document."));
 		}
 	}
 }

--- a/src/org/revager/export/ReviewProtocolPDFExporter.java
+++ b/src/org/revager/export/ReviewProtocolPDFExporter.java
@@ -18,7 +18,7 @@
  */
 package org.revager.export;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import org.revager.app.Application;
 import org.revager.app.model.ApplicationData;
@@ -88,7 +88,7 @@ public class ReviewProtocolPDFExporter extends ProtocolPDFExporter {
 	 */
 	public ReviewProtocolPDFExporter(String filePath, boolean showSignFields, boolean attachProdExtRefs,
 			boolean attachFindExtRefs) throws ExportException, DataException {
-		super(filePath, _("List of Findings") + " · " + reviewTitle,
+		super(filePath, translate("List of Findings") + " · " + reviewTitle,
 				appData.getSetting(AppSettingKey.PDF_PROTOCOL_LOGO),
 				appData.getSetting(AppSettingKey.PDF_PROTOCOL_FOOT_TEXT));
 
@@ -125,7 +125,7 @@ public class ReviewProtocolPDFExporter extends ProtocolPDFExporter {
 				table.setWidthPercentage(100);
 
 				PdfPCell cellSignIntro = new PdfPCell(
-						new Phrase(_("The following persons participated in the whole review:"), introFont));
+						new Phrase(translate("The following persons participated in the whole review:"), introFont));
 				cellSignIntro.setBorderWidth(0);
 				cellSignIntro.setPadding(padding);
 				cellSignIntro.setPaddingBottom(PDFTools.cmToPt(0.8f));
@@ -155,7 +155,7 @@ public class ReviewProtocolPDFExporter extends ProtocolPDFExporter {
 			 * Not part of unit testing because this exception is only thrown if
 			 * an internal error occurs.
 			 */
-			throw new ExportException(_("Cannot create PDF document."));
+			throw new ExportException(translate("Cannot create PDF document."));
 		}
 	}
 

--- a/src/org/revager/gui/AbstractDialog.java
+++ b/src/org/revager/gui/AbstractDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -465,7 +465,7 @@ public abstract class AbstractDialog extends JDialog {
 		helpButtonLayout.setVgap(10);
 
 		buttonHelp = GUITools.newImageToggleButton();
-		buttonHelp.setToolTipText(_("Show/hide help"));
+		buttonHelp.setToolTipText(translate("Show/hide help"));
 		buttonHelp.setIcon(ICON_OPEN_HELP);
 		buttonHelp.setSelectedIcon(ICON_CLOSE_HELP);
 		buttonHelp.setRolloverIcon(ICON_OPEN_HELP_ROLLOVER);
@@ -554,7 +554,7 @@ public abstract class AbstractDialog extends JDialog {
 	 * Switch to progress mode.
 	 */
 	public void switchToProgressMode() {
-		switchToProgressMode(_("Work in progress ..."));
+		switchToProgressMode(translate("Work in progress ..."));
 	}
 
 	/**
@@ -581,7 +581,7 @@ public abstract class AbstractDialog extends JDialog {
 			/*
 			 * Show "wait..." as label
 			 */
-			JLabel wait = new JLabel(_("Loading help ..."), ICON_WAIT, SwingConstants.CENTER);
+			JLabel wait = new JLabel(translate("Loading help ..."), ICON_WAIT, SwingConstants.CENTER);
 
 			panelHelp.setLayout(new BorderLayout());
 			panelHelp.add(wait, BorderLayout.CENTER);

--- a/src/org/revager/gui/AbstractFrame.java
+++ b/src/org/revager/gui/AbstractFrame.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -202,7 +202,7 @@ public class AbstractFrame extends JFrame {
 	/**
 	 * The format time.
 	 */
-	private DateFormat formatTime = new SimpleDateFormat(_("HH:mm"));
+	private DateFormat formatTime = new SimpleDateFormat(translate("HH:mm"));
 
 	/**
 	 * The number of hints.
@@ -521,7 +521,7 @@ public class AbstractFrame extends JFrame {
 		/*
 		 * Construct the button to toggle the hints
 		 */
-		buttonHints.setToolTipText(_("Show/hide hints"));
+		buttonHints.setToolTipText(translate("Show/hide hints"));
 		buttonHints.setIcon(ICON_CLOSE_HINTS);
 		buttonHints.setRolloverIcon(ICON_CLOSE_HINTS_ROLLOVER);
 		buttonHints.setRolloverSelectedIcon(ICON_OPEN_HINTS_ROLLOVER);
@@ -538,7 +538,7 @@ public class AbstractFrame extends JFrame {
 		 */
 		statusMessage.setFont(FONT_TEXT);
 		statusMessage.setForeground(Color.DARK_GRAY);
-		setStatusMessage(_("No review in process."), false);
+		setStatusMessage(translate("No review in process."), false);
 
 		GridBagLayout gblBottom = new GridBagLayout();
 		panelBottom.setLayout(gblBottom);
@@ -781,7 +781,7 @@ public class AbstractFrame extends JFrame {
 				 * 
 				 * });
 				 * 
-				 * try { helpButton .setToolTipText(_("Open help chapter") + " "
+				 * try { helpButton .setToolTipText(translate("Open help chapter") + " "
 				 * + Data.getInstance() .getHelpData() .getChapterTitle(
 				 * HINT.getHelpChapter())); } catch (DataException e) {
 				 * helpButton.setVisible(false); }
@@ -867,7 +867,7 @@ public class AbstractFrame extends JFrame {
 	 * Switch to progress mode.
 	 */
 	public void switchToProgressMode() {
-		switchToProgressMode(_("Work in progress ..."));
+		switchToProgressMode(translate("Work in progress ..."));
 	}
 
 	/**

--- a/src/org/revager/gui/DirectoryPopupWindow.java
+++ b/src/org/revager/gui/DirectoryPopupWindow.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -96,7 +96,7 @@ public class DirectoryPopupWindow extends JDialog {
 
 		// setUndecorated(true);
 		setResizable(false);
-		setTitle(_("RevAger"));
+		setTitle(translate("RevAger"));
 
 		setModal(true);
 
@@ -111,11 +111,11 @@ public class DirectoryPopupWindow extends JDialog {
 
 		inputPanel.setBackground(Color.WHITE);
 
-		filterLbl = new JLabel(_("Filter:"));
-		attFilterLbl = new JLabel(_("Filtered attendees:"));
+		filterLbl = new JLabel(translate("Filter:"));
+		attFilterLbl = new JLabel(translate("Filtered attendees:"));
 		deleteBttn = GUITools.newImageButton(Data.getInstance().getIcon("remove_25x25_0.png"),
 				Data.getInstance().getIcon("remove_25x25.png"));
-		deleteBttn.setToolTipText(_("Remove attendee from address book"));
+		deleteBttn.setToolTipText(translate("Remove attendee from address book"));
 		deleteBttn.addActionListener(new ActionListener() {
 
 			@Override
@@ -192,13 +192,13 @@ public class DirectoryPopupWindow extends JDialog {
 		JButton buttonAbort = GUITools.newImageButton();
 		buttonAbort.setIcon(Data.getInstance().getIcon("buttonCancel_24x24_0.png"));
 		buttonAbort.setRolloverIcon(Data.getInstance().getIcon("buttonCancel_24x24.png"));
-		buttonAbort.setToolTipText(_("Abort"));
+		buttonAbort.setToolTipText(translate("Abort"));
 		buttonAbort.addActionListener(new DirectoryPopupWindowAction(this, ButtonClicked.ABORT));
 
 		JButton buttonConfirm = GUITools.newImageButton();
 		buttonConfirm.setIcon(Data.getInstance().getIcon("buttonOk_24x24_0.png"));
 		buttonConfirm.setRolloverIcon(Data.getInstance().getIcon("buttonOk_24x24.png"));
-		buttonConfirm.setToolTipText(_("Confirm"));
+		buttonConfirm.setToolTipText(translate("Confirm"));
 		buttonConfirm.addActionListener(new DirectoryPopupWindowAction(this, ButtonClicked.OK));
 
 		JPanel panelButtons = new JPanel(new BorderLayout());

--- a/src/org/revager/gui/HelpBrowserFrame.java
+++ b/src/org/revager/gui/HelpBrowserFrame.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -99,7 +99,7 @@ public class HelpBrowserFrame extends AbstractFrame {
 
 		setStatusBarVisible(false);
 
-		setTitle(_("RevAger Online Help"));
+		setTitle(translate("RevAger Online Help"));
 
 		getContentPane().setLayout(new BorderLayout());
 
@@ -123,7 +123,7 @@ public class HelpBrowserFrame extends AbstractFrame {
 				ActionRegistry.getInstance().get(SearchHelpAction.class.getName()).actionPerformed(null);
 			}
 		});
-		srchTxtFld.setToolTipText(_("Filter/Search - Enter search item ..."));
+		srchTxtFld.setToolTipText(translate("Filter/Search - Enter search item ..."));
 		srchTxtFld.setColumns(30);
 		srchTxtFld.setBorder(BorderFactory.createLineBorder(Color.GRAY, 1));
 		srchTxtFld.setBackground(new Color(254, 255, 193));
@@ -131,11 +131,11 @@ public class HelpBrowserFrame extends AbstractFrame {
 		JButton reset = GUITools.newImageButton();
 		reset.setIcon(Data.getInstance().getIcon("undo_22x22_0.png"));
 		reset.setRolloverIcon(Data.getInstance().getIcon("undo_22x22.png"));
-		reset.setToolTipText(_("Reset filter"));
+		reset.setToolTipText(translate("Reset filter"));
 		reset.addActionListener(ActionRegistry.getInstance().get(ResetHelpAction.class.getName()));
 
 		JTextArea descText = new JTextArea(
-				_("Please enter a search item into the input field to filter the contents:"));
+				translate("Please enter a search item into the input field to filter the contents:"));
 		descText.setEditable(false);
 		descText.setFont(FONT_TEXT);
 		descText.setForeground(Color.DARK_GRAY);
@@ -154,8 +154,8 @@ public class HelpBrowserFrame extends AbstractFrame {
 			helpStartTitle = Data.getInstance().getHelpData().getChapterTitle("start");
 			helpStartContent = Data.getInstance().getHelpData().getChapterContent("start");
 		} catch (DataException startMissingError) {
-			JOptionPane.showMessageDialog(UI.getInstance().getMainFrame(), _("Cannot load the start page."),
-					_("Error occured"), JOptionPane.ERROR_MESSAGE);
+			JOptionPane.showMessageDialog(UI.getInstance().getMainFrame(), translate("Cannot load the start page."),
+					translate("Error occured"), JOptionPane.ERROR_MESSAGE);
 		}
 
 		tree = new JTree(getStandardRoot());
@@ -330,7 +330,7 @@ public class HelpBrowserFrame extends AbstractFrame {
 	 * Sets the error page.
 	 */
 	private void setErrorPage() {
-		bodyPane.setText("<H1>" + _("Error") + "</H1>" + "<P>" + _("Cannot find help page.") + "</P>");
+		bodyPane.setText("<H1>" + translate("Error") + "</H1>" + "<P>" + translate("Cannot find help page.") + "</P>");
 	}
 
 	/**

--- a/src/org/revager/gui/MainFrame.java
+++ b/src/org/revager/gui/MainFrame.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -137,7 +137,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 	private JButton removeAttendee;
 	private JButton editAttendee;
 
-	private DefaultMutableTreeNode nodeMeetingRoot = new DefaultMutableTreeNode(_("All meetings"));
+	private DefaultMutableTreeNode nodeMeetingRoot = new DefaultMutableTreeNode(translate("All meetings"));
 	private DefaultTreeModel meetingsTreeModel = new DefaultTreeModel(nodeMeetingRoot);
 	private JTree meetingsTree;
 
@@ -341,29 +341,29 @@ public class MainFrame extends AbstractFrame implements Observer {
 		/*
 		 * creating the left panel
 		 */
-		product = new JLabel(_("Product:"));
+		product = new JLabel(translate("Product:"));
 
 		textProduct.setFocusable(false);
 
-		reviewName = new JLabel(_("Title of the review:"));
+		reviewName = new JLabel(translate("Title of the review:"));
 		reviewName.setBorder(labelBorder);
 		textRevName.addKeyListener(updKeyListener);
 
-		reviewDescription = new JLabel(_("Description of the review:"));
+		reviewDescription = new JLabel(translate("Description of the review:"));
 		reviewDescription.setBorder(labelBorder);
 		textRevDesc.addKeyListener(updKeyListener);
 
 		scrollRevDesc = GUITools.setIntoScrllPn(textRevDesc);
 
 		commentReview.setIcon(Data.getInstance().getIcon("comment_16x16.png"));
-		commentReview.setText(_("Comments on the review"));
+		commentReview.setText(translate("Comments on the review"));
 		commentReview.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				String comments = revMgmt.getReviewComments();
 
 				TextPopupWindow popup = new TextPopupWindow(UI.getInstance().getMainFrame(),
-						_("Comments on the review:"), comments, true);
+						translate("Comments on the review:"), comments, true);
 
 				popup.setVisible(true);
 
@@ -436,7 +436,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 		 */
 		rightPanel.setBorder(new MatteBorder(0, 1, 0, 0, UI.SEPARATOR_COLOR));
 
-		meetings = new JLabel(_("Review Meetings:"));
+		meetings = new JLabel(translate("Review Meetings:"));
 
 		MeetingsTreeRenderer renderer = new MeetingsTreeRenderer();
 
@@ -559,14 +559,14 @@ public class MainFrame extends AbstractFrame implements Observer {
 		removeMeeting = GUITools.newImageButton();
 		removeMeeting.setIcon(Data.getInstance().getIcon("remove_25x25_0.png"));
 		removeMeeting.setRolloverIcon(Data.getInstance().getIcon("remove_25x25.png"));
-		removeMeeting.setToolTipText(_("Remove"));
+		removeMeeting.setToolTipText(translate("Remove"));
 		removeMeeting.addActionListener(ActionRegistry.getInstance().get(RemoveMeetingAction.class.getName()));
 		meetingButtons.add(removeMeeting);
 
 		editMeeting = GUITools.newImageButton();
 		editMeeting.setIcon(Data.getInstance().getIcon("edit_25x25_0.png"));
 		editMeeting.setRolloverIcon(Data.getInstance().getIcon("edit_25x25.png"));
-		editMeeting.setToolTipText(_("Modify meeting"));
+		editMeeting.setToolTipText(translate("Modify meeting"));
 		editMeeting.addActionListener(ActionRegistry.getInstance().get(EditMeetingAction.class.getName()));
 
 		meetingButtons.add(editMeeting);
@@ -574,14 +574,14 @@ public class MainFrame extends AbstractFrame implements Observer {
 		commentMeeting = GUITools.newImageButton();
 		commentMeeting.setIcon(Data.getInstance().getIcon("comment_25x25_0.png"));
 		commentMeeting.setRolloverIcon(Data.getInstance().getIcon("comment_25x25.png"));
-		commentMeeting.setToolTipText(_("Comment meeting"));
+		commentMeeting.setToolTipText(translate("Comment meeting"));
 		commentMeeting.addActionListener(ActionRegistry.getInstance().get(CommentMeetingAction.class.getName()));
 		meetingButtons.add(commentMeeting);
 
 		editProtocol = GUITools.newImageButton();
 		editProtocol.setIcon(Data.getInstance().getIcon("protocolFrame_25x25_0.png"));
 		editProtocol.setRolloverIcon(Data.getInstance().getIcon("protocolFrame_25x25.png"));
-		editProtocol.setToolTipText(_("Open/create list of findings"));
+		editProtocol.setToolTipText(translate("Open/create list of findings"));
 		editProtocol.addActionListener(ActionRegistry.getInstance().get(OpenFindingsListAction.class.getName()));
 
 		meetingButtons.add(editProtocol);
@@ -591,7 +591,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 		removeMeeting.setEnabled(false);
 		editProtocol.setEnabled(false);
 
-		attendees = new JLabel(_("Attendees of the review:"));
+		attendees = new JLabel(translate("Attendees of the review:"));
 		attendees.setBorder(labelBorder);
 		attendeesTable = GUITools.newStandardTable(attendeesTableModel, false);
 		attendeesTable.getColumnModel().getColumn(2).setPreferredWidth(50);
@@ -698,14 +698,14 @@ public class MainFrame extends AbstractFrame implements Observer {
 		removeAttendee = GUITools.newImageButton();
 		removeAttendee.setIcon(Data.getInstance().getIcon("removeAttendee_25x25_0.png"));
 		removeAttendee.setRolloverIcon(Data.getInstance().getIcon("removeAttendee_25x25.png"));
-		removeAttendee.setToolTipText(_("Remove attendee"));
+		removeAttendee.setToolTipText(translate("Remove attendee"));
 		removeAttendee.addActionListener(ActionRegistry.getInstance().get(RemoveAttendeeAction.class.getName()));
 		attendeeButtons.add(removeAttendee);
 
 		editAttendee = GUITools.newImageButton();
 		editAttendee.setIcon(Data.getInstance().getIcon("editAttendee_25x25_0.png"));
 		editAttendee.setRolloverIcon(Data.getInstance().getIcon("editAttendee_25x25.png"));
-		editAttendee.setToolTipText(_("Modify attendee"));
+		editAttendee.setToolTipText(translate("Modify attendee"));
 		editAttendee.addActionListener(ActionRegistry.getInstance().get(EditAttendeeAction.class.getName()));
 		attendeeButtons.add(editAttendee);
 
@@ -714,13 +714,13 @@ public class MainFrame extends AbstractFrame implements Observer {
 		removeAttendee.setEnabled(false);
 		editAttendee.setEnabled(false);
 
-		generalImpression = new JLabel(_("General impression of the product:"));
+		generalImpression = new JLabel(translate("General impression of the product:"));
 		generalImpression.setBorder(labelBorder);
 
 		scrollImpression = GUITools.setIntoScrllPn(impressionTxtArea);
 		impressionTxtArea.addKeyListener(updKeyListener);
 
-		recommendation = new JLabel(_("Final recommendation for the product:"));
+		recommendation = new JLabel(translate("Final recommendation for the product:"));
 		recommendation.setBorder(labelBorder);
 		recommendationBx.setEditable(true);
 		for (String rec : Data.getDefaultRecommendations()) {
@@ -794,7 +794,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 	private void createToolBar() {
 		tbShowAssistant = GUITools.newImageButton(Data.getInstance().getIcon("tbShowAssistant_50x50_0.png"),
 				Data.getInstance().getIcon("tbShowAssistant_50x50.png"));
-		tbShowAssistant.setToolTipText(_("Open RevAger Assistant"));
+		tbShowAssistant.setToolTipText(translate("Open RevAger Assistant"));
 		tbShowAssistant.addActionListener(ActionRegistry.getInstance().get(OpenAssistantAction.class.getName()));
 
 		addTopComponent(tbShowAssistant);
@@ -822,7 +822,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 		// tbShowHelp = GUITools.newImageButton(
 		// Data.getInstance().getIcon("tbShowHelp_50x50_0.png"), Data
 		// .getInstance().getIcon("tbShowHelp_50x50.png"));
-		// tbShowHelp.setToolTipText(_("Open RevAger Help"));
+		// tbShowHelp.setToolTipText(translate("Open RevAger Help"));
 		// tbShowHelp.addActionListener(ActionRegistry.getInstance().get(
 		// OpenHelpAction.class.getName()));
 		//
@@ -909,7 +909,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 		 * File menu
 		 */
 		menuFile = new JMenu();
-		menuFile.setText(_("File"));
+		menuFile.setText(translate("File"));
 
 		fileSelectModeItem = new JMenuItem(ActionRegistry.getInstance().get(OpenAssistantAction.class.getName()));
 
@@ -945,7 +945,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 		 * Edit menu
 		 */
 		menuEdit = new JMenu();
-		menuEdit.setText(_("Edit"));
+		menuEdit.setText(translate("Edit"));
 
 		newMeetingItem = new JMenuItem(ActionRegistry.getInstance().get(AddMeetingAction.class.getName()));
 
@@ -988,10 +988,10 @@ public class MainFrame extends AbstractFrame implements Observer {
 		 * Extras menu
 		 */
 		menuSettings = new JMenu();
-		menuSettings.setText(_("Settings"));
+		menuSettings.setText(translate("Settings"));
 
 		appSettings = new JMenuItem();
-		appSettings.setText(_("Application Settings"));
+		appSettings.setText(translate("Application Settings"));
 		appSettings.setIcon(Data.getInstance().getIcon("menuAppSettings_16x16.png"));
 		appSettings.addActionListener(new ActionListener() {
 			@Override
@@ -1004,7 +1004,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 		menuSettings.add(appSettings);
 
 		csvProfiles = new JMenuItem();
-		csvProfiles.setText(_("CSV Profiles"));
+		csvProfiles.setText(translate("CSV Profiles"));
 		csvProfiles.setIcon(Data.getInstance().getIcon("menuCsvSettings_16x16.png"));
 		csvProfiles.addActionListener(new ActionListener() {
 			@Override
@@ -1021,12 +1021,12 @@ public class MainFrame extends AbstractFrame implements Observer {
 		 * Help menu
 		 */
 		menuHelp = new JMenu();
-		menuHelp.setText(_("Help"));
+		menuHelp.setText(translate("Help"));
 
 		// TODO HELP IS CURRENTLY DISABLED!
 
 		// openHelp = new JMenuItem();
-		// openHelp.setText(_("Open Help Browser"));
+		// openHelp.setText(translate("Open Help Browser"));
 		// openHelp.setIcon(Data.getInstance().getIcon("menuHelp_16x16.png"));
 		// openHelp.addActionListener(ActionRegistry.getInstance().get(
 		// OpenHelpAction.class.getName()));
@@ -1034,7 +1034,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 		// menuHelp.add(openHelp);
 
 		aboutHelp = new JMenuItem();
-		aboutHelp.setText(_("About RevAger"));
+		aboutHelp.setText(translate("About RevAger"));
 		aboutHelp.setIcon(Data.getInstance().getIcon("menuAbout_16x16.png"));
 		aboutHelp.addActionListener(new ActionListener() {
 			@Override
@@ -1154,7 +1154,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 		String product = productName;
 
 		if (!productVersion.trim().equals("") && !productName.trim().equals("")) {
-			product += " (" + _("Version:") + " " + productVersion + ")";
+			product += " (" + translate("Version:") + " " + productVersion + ")";
 		}
 
 		textProduct.setText(product);
@@ -1182,24 +1182,24 @@ public class MainFrame extends AbstractFrame implements Observer {
 	 * Creates the hints.
 	 */
 	private void createHints() {
-		hintStart = new HintItem(_("First of all we recommend to specify the product and the review's title."),
+		hintStart = new HintItem(translate("First of all we recommend to specify the product and the review's title."),
 				HintItem.WARNING);
 
 		hintMeetAtt = new HintItem(
-				_("You should create a meeting and add the attendees of the review by using the corresponding buttons."),
+				translate("You should create a meeting and add the attendees of the review by using the corresponding buttons."),
 				HintItem.WARNING);
 
-		hintOk = new HintItem(_("All required information for the review are present."), HintItem.OK);
+		hintOk = new HintItem(translate("All required information for the review are present."), HintItem.OK);
 		hintSecondOk = new HintItem(
-				_("Now you can export the list of findings either for the whole review or a single review meeting."),
+				translate("Now you can export the list of findings either for the whole review or a single review meeting."),
 				HintItem.INFO);
 
 		hintListOfFindings = new HintItem(
-				_("You can open the list of findings by selecting the corresponding meeting and clicking the 'Open findings list' button."),
+				translate("You can open the list of findings by selecting the corresponding meeting and clicking the 'Open findings list' button."),
 				HintItem.INFO);
 
 		hintInfoAssistant = new HintItem(
-				_("You can open the RevAger Assistant by clicking on the 'Open Assistant' button."), HintItem.INFO);
+				translate("You can open the RevAger Assistant by clicking on the 'Open Assistant' button."), HintItem.INFO);
 	}
 
 	/**
@@ -1461,12 +1461,12 @@ public class MainFrame extends AbstractFrame implements Observer {
 			if (UI.getInstance().getStatus() != Status.NO_FILE_LOADED) {
 				if (revName != null) {
 					if (revName.trim().equals("")) {
-						title = _("New Review");
+						title = translate("New Review");
 					} else {
 						title = revName;
 					}
 				} else {
-					title = _("New Review");
+					title = translate("New Review");
 				}
 
 				title += " - ";
@@ -1629,7 +1629,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 			tbProtocolMode.setEnabled(true);
 			editProtocol.setEnabled(true);
 
-			removeMeeting.setToolTipText(_("Remove meeting"));
+			removeMeeting.setToolTipText(translate("Remove meeting"));
 		} else if (getSelectedProtocol() != null) {
 			commentMeeting.setEnabled(false);
 			editMeeting.setEnabled(false);
@@ -1639,7 +1639,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 			tbProtocolMode.setEnabled(true);
 			editProtocol.setEnabled(true);
 
-			removeMeeting.setToolTipText(_("Remove list of findings"));
+			removeMeeting.setToolTipText(translate("Remove list of findings"));
 		} else {
 			commentMeeting.setEnabled(false);
 			editMeeting.setEnabled(false);
@@ -1649,7 +1649,7 @@ public class MainFrame extends AbstractFrame implements Observer {
 			tbProtocolMode.setEnabled(false);
 			editProtocol.setEnabled(false);
 
-			removeMeeting.setToolTipText(_("Remove"));
+			removeMeeting.setToolTipText(translate("Remove"));
 		}
 	}
 

--- a/src/org/revager/gui/StrengthPopupWindow.java
+++ b/src/org/revager/gui/StrengthPopupWindow.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -106,7 +106,7 @@ public class StrengthPopupWindow extends JDialog {
 
 		// setUndecorated(true);
 		setResizable(false);
-		setTitle(_("RevAger"));
+		setTitle(translate("RevAger"));
 
 		setModal(true);
 
@@ -131,13 +131,13 @@ public class StrengthPopupWindow extends JDialog {
 				}
 			}
 		} catch (DataException e) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 
 		selCateList = new ArrayList<String>();
 
-		JLabel labelFilter = new JLabel(_("Filter:"));
+		JLabel labelFilter = new JLabel(translate("Filter:"));
 
 		filterTxtFld = new JTextField();
 		filterTxtFld.addKeyListener(new KeyListener() {
@@ -157,7 +157,7 @@ public class StrengthPopupWindow extends JDialog {
 
 		JButton buttonClear = GUITools.newImageButton(Data.getInstance().getIcon("clear_22x22_0.png"),
 				Data.getInstance().getIcon("clear_22x22.png"));
-		buttonClear.setToolTipText(_("Reset filter"));
+		buttonClear.setToolTipText(translate("Reset filter"));
 		buttonClear.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -190,13 +190,13 @@ public class StrengthPopupWindow extends JDialog {
 		JButton buttonAbort = GUITools.newImageButton();
 		buttonAbort.setIcon(Data.getInstance().getIcon("buttonCancel_24x24_0.png"));
 		buttonAbort.setRolloverIcon(Data.getInstance().getIcon("buttonCancel_24x24.png"));
-		buttonAbort.setToolTipText(_("Abort"));
+		buttonAbort.setToolTipText(translate("Abort"));
 		buttonAbort.addActionListener(new StrengthPopupWindowAction(this, ButtonClicked.ABORT));
 
 		JButton buttonConfirm = GUITools.newImageButton();
 		buttonConfirm.setIcon(Data.getInstance().getIcon("buttonOk_24x24_0.png"));
 		buttonConfirm.setRolloverIcon(Data.getInstance().getIcon("buttonOk_24x24.png"));
-		buttonConfirm.setToolTipText(_("Confirm"));
+		buttonConfirm.setToolTipText(translate("Confirm"));
 		buttonConfirm.addActionListener(new StrengthPopupWindowAction(this, ButtonClicked.OK));
 
 		JPanel panelButtons = new JPanel(new BorderLayout());
@@ -274,7 +274,7 @@ public class StrengthPopupWindow extends JDialog {
 				}
 			}
 		} catch (Exception exc) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 

--- a/src/org/revager/gui/TextPopupWindow.java
+++ b/src/org/revager/gui/TextPopupWindow.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -74,7 +74,7 @@ public class TextPopupWindow extends JDialog {
 
 		// setUndecorated(true);
 		setResizable(false);
-		setTitle(_("RevAger"));
+		setTitle(translate("RevAger"));
 
 		setModal(true);
 
@@ -121,13 +121,13 @@ public class TextPopupWindow extends JDialog {
 		JButton buttonAbort = GUITools.newImageButton();
 		buttonAbort.setIcon(Data.getInstance().getIcon("buttonCancel_24x24_0.png"));
 		buttonAbort.setRolloverIcon(Data.getInstance().getIcon("buttonCancel_24x24.png"));
-		buttonAbort.setToolTipText(_("Abort"));
+		buttonAbort.setToolTipText(translate("Abort"));
 		buttonAbort.addActionListener(new TextPopupWindowAction(this, ButtonClicked.ABORT));
 
 		JButton buttonConfirm = GUITools.newImageButton();
 		buttonConfirm.setIcon(Data.getInstance().getIcon("buttonOk_24x24_0.png"));
 		buttonConfirm.setRolloverIcon(Data.getInstance().getIcon("buttonOk_24x24.png"));
-		buttonConfirm.setToolTipText(_("Confirm"));
+		buttonConfirm.setToolTipText(translate("Confirm"));
 		buttonConfirm.addActionListener(new TextPopupWindowAction(this, ButtonClicked.OK));
 
 		JPanel panelButtons = new JPanel(new BorderLayout());

--- a/src/org/revager/gui/UI.java
+++ b/src/org/revager/gui/UI.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Color;
 import java.awt.Font;
@@ -763,12 +763,12 @@ public class UI implements Observer {
 
 			// getMainFrame().setEnabled(false);
 
-			Object[] options = { _("Restore"), _("Discard") };
+			Object[] options = { translate("Restore"), translate("Discard") };
 
 			if (JOptionPane.showOptionDialog(mainFrame,
 					GUITools.getMessagePane(
-							_("There is a review which hasn't been stored properly. Would you like to restore and load the review?")),
-					_("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options,
+							translate("There is a review which hasn't been stored properly. Would you like to restore and load the review?")),
+					translate("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options,
 					options[0]) == JOptionPane.YES_OPTION) {
 				// getMainFrame().setEnabled(true);
 

--- a/src/org/revager/gui/actions/ExitAction.java
+++ b/src/org/revager/gui/actions/ExitAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -49,7 +49,7 @@ public class ExitAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuExit_16x16.png"));
-		putValue(NAME, _("Close Application"));
+		putValue(NAME, translate("Close Application"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_Q, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}
@@ -74,8 +74,8 @@ public class ExitAction extends AbstractAction {
 		if (status == Status.UNSAVED_CHANGES) {
 			int option = JOptionPane.showConfirmDialog(UI.getInstance().getMainFrame(),
 					GUITools.getMessagePane(
-							_("There are unsaved changes in the review. Would you like to save them now?\n\nAttention: If you choose 'No' all unsaved information will get lost.")),
-					_("Question"), JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+							translate("There are unsaved changes in the review. Would you like to save them now?\n\nAttention: If you choose 'No' all unsaved information will get lost.")),
+					translate("Question"), JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
 
 			if (option == JOptionPane.YES_OPTION) {
 				((SaveReviewAction) ActionRegistry.getInstance().get(SaveReviewAction.class.getName()))

--- a/src/org/revager/gui/actions/InitializeNewReviewAction.java
+++ b/src/org/revager/gui/actions/InitializeNewReviewAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 
@@ -65,7 +65,7 @@ public class InitializeNewReviewAction extends AbstractAction {
 
 				GUITools.executeSwingWorker(new NewReviewWorker(true));
 			} else {
-				String message = _("Please enter the name of the attendee.");
+				String message = translate("Please enter the name of the attendee.");
 
 				assistant.setMessage(message);
 

--- a/src/org/revager/gui/actions/LoadReviewAction.java
+++ b/src/org/revager/gui/actions/LoadReviewAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -47,7 +47,7 @@ public class LoadReviewAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuOpen_16x16.png"));
-		putValue(NAME, _("Open Review..."));
+		putValue(NAME, translate("Open Review..."));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_O, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}

--- a/src/org/revager/gui/actions/ManageSeveritiesAction.java
+++ b/src/org/revager/gui/actions/ManageSeveritiesAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -43,7 +43,7 @@ public class ManageSeveritiesAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuManSev_16x16.png"));
-		putValue(NAME, _("Manage Severities"));
+		putValue(NAME, translate("Manage Severities"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_G, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}

--- a/src/org/revager/gui/actions/NewReviewAction.java
+++ b/src/org/revager/gui/actions/NewReviewAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -46,7 +46,7 @@ public class NewReviewAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuNew_16x16.png"));
-		putValue(NAME, _("New Review"));
+		putValue(NAME, translate("New Review"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_N, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}
@@ -62,8 +62,8 @@ public class NewReviewAction extends AbstractAction {
 		if (UI.getInstance().getStatus() == UI.Status.UNSAVED_CHANGES) {
 			int option = JOptionPane.showConfirmDialog(org.revager.gui.UI.getInstance().getMainFrame(),
 					GUITools.getMessagePane(
-							_("There are unsaved changes in the review. Would you like to save them now?\n\nAttention: If you choose 'No' all unsaved information will get lost.")),
-					_("Question"), JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+							translate("There are unsaved changes in the review. Would you like to save them now?\n\nAttention: If you choose 'No' all unsaved information will get lost.")),
+					translate("Question"), JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
 
 			if (option == JOptionPane.YES_OPTION) {
 				ActionRegistry.getInstance().get(SaveReviewAction.class.getName()).actionPerformed(null);

--- a/src/org/revager/gui/actions/OpenAspectsManagerAction.java
+++ b/src/org/revager/gui/actions/OpenAspectsManagerAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -43,7 +43,7 @@ public class OpenAspectsManagerAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuAspMan_16x16.png"));
-		putValue(NAME, _("Manage Aspects"));
+		putValue(NAME, translate("Manage Aspects"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_R, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}

--- a/src/org/revager/gui/actions/OpenExpCSVDialogAction.java
+++ b/src/org/revager/gui/actions/OpenExpCSVDialogAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -43,7 +43,7 @@ public class OpenExpCSVDialogAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuCsvExport_16x16.png"));
-		putValue(NAME, _("Export Findings into a CSV File"));
+		putValue(NAME, translate("Export Findings into a CSV File"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_B, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}

--- a/src/org/revager/gui/actions/OpenExpPDFDialogAction.java
+++ b/src/org/revager/gui/actions/OpenExpPDFDialogAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -43,7 +43,7 @@ public class OpenExpPDFDialogAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuPdfExport_16x16.png"));
-		putValue(NAME, _("Export Findings List as PDF File"));
+		putValue(NAME, translate("Export Findings List as PDF File"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_F, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}

--- a/src/org/revager/gui/actions/OpenFindingsListAction.java
+++ b/src/org/revager/gui/actions/OpenFindingsListAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -68,7 +68,7 @@ public class OpenFindingsListAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuProt_16x16.png"));
-		putValue(NAME, _("Open/Create Findings List"));
+		putValue(NAME, translate("Open/Create Findings List"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}

--- a/src/org/revager/gui/actions/OpenInvitationsDialogAction.java
+++ b/src/org/revager/gui/actions/OpenInvitationsDialogAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -43,7 +43,7 @@ public class OpenInvitationsDialogAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuCreateInv_16x16.png"));
-		putValue(NAME, _("Create Invitations"));
+		putValue(NAME, translate("Create Invitations"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_E, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}

--- a/src/org/revager/gui/actions/SaveReviewAction.java
+++ b/src/org/revager/gui/actions/SaveReviewAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -55,7 +55,7 @@ public class SaveReviewAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuSave_16x16.png"));
-		putValue(NAME, _("Save Review"));
+		putValue(NAME, translate("Save Review"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_S, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}
@@ -86,14 +86,14 @@ public class SaveReviewAction extends AbstractAction {
 		}
 
 		if (reviewPath != null) {
-			Object[] options = { _("Ignore"), _("Correct") };
+			Object[] options = { translate("Ignore"), translate("Correct") };
 
 			if (revMgmt.hasExtRefs()
 					&& (reviewPath.trim().toLowerCase().endsWith(ENDING_XML)
 							|| reviewPath.trim().toLowerCase().endsWith(".xml"))
 					&& JOptionPane.showOptionDialog(UI.getInstance().getMainFrame(),
-							_("This review contains attachments. It is not possible to store them inside the XML file, so they'll get lost."),
-							_("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options,
+							translate("This review contains attachments. It is not possible to store them inside the XML file, so they'll get lost."),
+							translate("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options,
 							options[0]) == JOptionPane.NO_OPTION) {
 				ActionRegistry.getInstance().get(SaveReviewAsAction.class.getName()).actionPerformed(e);
 

--- a/src/org/revager/gui/actions/SaveReviewAsAction.java
+++ b/src/org/revager/gui/actions/SaveReviewAsAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 import java.io.File;
@@ -52,7 +52,7 @@ public class SaveReviewAsAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuSaveAs_16x16.png"));
-		putValue(NAME, _("Save Review as..."));
+		putValue(NAME, translate("Save Review as..."));
 	}
 
 	/*
@@ -80,15 +80,15 @@ public class SaveReviewAsAction extends AbstractAction {
 				ResiFileFilter.TYPE_REVIEW) == FileChooser.SELECTED_APPROVE) {
 			String reviewPath = fileChooser.getFile().getAbsolutePath();
 
-			Object[] options = { _("Ignore"), _("Correct") };
+			Object[] options = { translate("Ignore"), translate("Correct") };
 
 			if (revMgmt.hasExtRefs()
 					&& (reviewPath.trim().toLowerCase().endsWith(ENDING_XML)
 							|| reviewPath.trim().toLowerCase().endsWith(".xml"))
 					&& JOptionPane.showOptionDialog(UI.getInstance().getMainFrame(),
 							GUITools.getMessagePane(
-									_("This review contains attachments. It is not possible to store them inside the XML file, so they'll get lost.")),
-							_("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options,
+									translate("This review contains attachments. It is not possible to store them inside the XML file, so they'll get lost.")),
+							translate("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null, options,
 							options[0]) == JOptionPane.NO_OPTION) {
 				this.setExitApplication(exitApp);
 				this.actionPerformed(e);

--- a/src/org/revager/gui/actions/assistant/OpenAssistantAction.java
+++ b/src/org/revager/gui/actions/assistant/OpenAssistantAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.assistant;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -52,7 +52,7 @@ public class OpenAssistantAction extends AbstractAction {
 		super();
 
 		putValue(Action.SMALL_ICON, Data.getInstance().getIcon("menuAssistant_16x16.png"));
-		putValue(Action.NAME, _("Open RevAger Assistant"));
+		putValue(Action.NAME, translate("Open RevAger Assistant"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_M, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}
@@ -74,8 +74,8 @@ public class OpenAssistantAction extends AbstractAction {
 		if (status == Status.UNSAVED_CHANGES) {
 			int option = JOptionPane.showConfirmDialog(UI.getInstance().getMainFrame(),
 					GUITools.getMessagePane(
-							_("There are unsaved changes in the review. Would you like to save them now?\n\nAttention: If you choose 'No' all unsaved information will get lost.")),
-					_("Question"), JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+							translate("There are unsaved changes in the review. Would you like to save them now?\n\nAttention: If you choose 'No' all unsaved information will get lost.")),
+					translate("Question"), JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
 
 			if (option == JOptionPane.YES_OPTION) {
 				ActionRegistry.getInstance().get(SaveReviewAction.class.getName()).actionPerformed(e);
@@ -86,7 +86,7 @@ public class OpenAssistantAction extends AbstractAction {
 			}
 		}
 
-		mainframe.setStatusMessage(_("No review in process."), false);
+		mainframe.setStatusMessage(translate("No review in process."), false);
 
 		mainframe.switchToClearMode();
 

--- a/src/org/revager/gui/actions/assistant/SelectLanguageAction.java
+++ b/src/org/revager/gui/actions/assistant/SelectLanguageAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.assistant;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 
@@ -58,7 +58,7 @@ public class SelectLanguageAction extends AbstractAction {
 	public void actionPerformed(ActionEvent ev) {
 
 		if (UI.getInstance().getAssistantDialog().isVisible())
-			popup = new LanguagePopupWindow(UI.getInstance().getAssistantDialog(), _("Select language"));
+			popup = new LanguagePopupWindow(UI.getInstance().getAssistantDialog(), translate("Select language"));
 		popup.setVisible(true);
 
 		if (popup.getButtonClicked() == LanguagePopupWindow.ButtonClicked.OK) {
@@ -67,15 +67,15 @@ public class SelectLanguageAction extends AbstractAction {
 
 				int option = JOptionPane.showConfirmDialog(UI.getInstance().getAssistantDialog(),
 						GUITools.getMessagePane(
-								_("You have to restart the application in order finalize the change of language. Restart now?")),
-						_("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+								translate("You have to restart the application in order finalize the change of language. Restart now?")),
+						translate("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
 
 				if (option == JOptionPane.YES_OPTION) {
 					Main.restartApplication();
 				}
 			} catch (DataException e) {
 				JOptionPane.showMessageDialog(UI.getInstance().getAssistantDialog(),
-						GUITools.getMessagePane(e.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+						GUITools.getMessagePane(e.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 			}
 		}
 	}

--- a/src/org/revager/gui/actions/attendee/AddAttToProtAction.java
+++ b/src/org/revager/gui/actions/attendee/AddAttToProtAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.attendee;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 
@@ -45,7 +45,7 @@ public class AddAttToProtAction extends AbstractAction {
 	 */
 	@Override
 	public void actionPerformed(ActionEvent arg0) {
-		AddAttToFLPopupWindow popup = new AddAttToFLPopupWindow(UI.getInstance().getProtocolFrame(), _("Add Attendee"),
+		AddAttToFLPopupWindow popup = new AddAttToFLPopupWindow(UI.getInstance().getProtocolFrame(), translate("Add Attendee"),
 				false);
 		popup.setVisible(true);
 

--- a/src/org/revager/gui/actions/attendee/AddAttendeeAction.java
+++ b/src/org/revager/gui/actions/attendee/AddAttendeeAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.attendee;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -43,7 +43,7 @@ public class AddAttendeeAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuNewAtt_16x16.png"));
-		putValue(NAME, _("Add Attendee"));
+		putValue(NAME, translate("Add Attendee"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_T, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}

--- a/src/org/revager/gui/actions/attendee/ConfirmAttendeeAction.java
+++ b/src/org/revager/gui/actions/attendee/ConfirmAttendeeAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.attendee;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 
@@ -79,7 +79,7 @@ public class ConfirmAttendeeAction extends AbstractAction {
 		}
 
 		if (nameMissing) {
-			message = _("Please enter the name of the attendee.");
+			message = translate("Please enter the name of the attendee.");
 
 			attDialog.setMessage(message);
 			nameTxtFld.setBorder(UI.MARKED_BORDER_INLINE);
@@ -109,7 +109,7 @@ public class ConfirmAttendeeAction extends AbstractAction {
 					currAppAtt.addStrength(str);
 				}
 			} catch (DataException e) {
-				JOptionPane.showMessageDialog(attDialog, GUITools.getMessagePane(e.getMessage()), _("Error"),
+				JOptionPane.showMessageDialog(attDialog, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 						JOptionPane.ERROR_MESSAGE);
 			}
 
@@ -126,7 +126,7 @@ public class ConfirmAttendeeAction extends AbstractAction {
 				if (!Application.getInstance().getAttendeeMgmt().isAttendee(newAtt)) {
 					Application.getInstance().getAttendeeMgmt().addAttendee(attName, attContact, attRole, null);
 				} else {
-					attDialog.setMessage(_(
+					attDialog.setMessage(translate(
 							"There is an attendee with the given information already existing. Please change the name, the contact information or the role of the attendee you would like to add."));
 
 					return;
@@ -136,7 +136,7 @@ public class ConfirmAttendeeAction extends AbstractAction {
 
 				if (Application.getInstance().getAttendeeComp().compare(currAtt, newAtt) != 0) {
 					if (!Application.getInstance().getAttendeeMgmt().editAttendee(currAtt, newAtt)) {
-						attDialog.setMessage(_(
+						attDialog.setMessage(translate(
 								"There is an attendee with the given information already existing. Please change the name, the contact information or the role of the attendee you would like to add."));
 
 						return;

--- a/src/org/revager/gui/actions/attendee/EditAttFromProtAction.java
+++ b/src/org/revager/gui/actions/attendee/EditAttFromProtAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.attendee;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 
@@ -44,7 +44,7 @@ public class EditAttFromProtAction extends AbstractAction {
 	 */
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		AddAttToFLPopupWindow popup = new AddAttToFLPopupWindow(UI.getInstance().getProtocolFrame(), _("Edit Attendee"),
+		AddAttToFLPopupWindow popup = new AddAttToFLPopupWindow(UI.getInstance().getProtocolFrame(), translate("Edit Attendee"),
 				true);
 		popup.setVisible(true);
 

--- a/src/org/revager/gui/actions/attendee/RemoveAttendeeAction.java
+++ b/src/org/revager/gui/actions/attendee/RemoveAttendeeAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.attendee;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 import java.text.MessageFormat;
@@ -73,11 +73,11 @@ public class RemoveAttendeeAction extends AbstractAction {
 			}
 
 			String compTxt = MessageFormat.format(
-					_("Cannot remove the selected attendee ({0}) from the current review because he/she is part of at least one meeting: {1}"),
+					translate("Cannot remove the selected attendee ({0}) from the current review because he/she is part of at least one meeting: {1}"),
 					nameTxt, meetTxt);
 
 			JOptionPane.showMessageDialog(org.revager.gui.UI.getInstance().getMainFrame(),
-					GUITools.getMessagePane(compTxt), _("Attention!"), JOptionPane.OK_OPTION);
+					GUITools.getMessagePane(compTxt), translate("Attention!"), JOptionPane.OK_OPTION);
 		}
 	}
 

--- a/src/org/revager/gui/actions/attendee/SelectAttOutOfDirAction.java
+++ b/src/org/revager/gui/actions/attendee/SelectAttOutOfDirAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.attendee;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 
@@ -44,9 +44,9 @@ public class SelectAttOutOfDirAction extends AbstractAction {
 	@Override
 	public void actionPerformed(ActionEvent ev) {
 		if (UI.getInstance().getAttendeeDialog().isVisible())
-			popup = new DirectoryPopupWindow(UI.getInstance().getAttendeeDialog(), _("Directory"));
+			popup = new DirectoryPopupWindow(UI.getInstance().getAttendeeDialog(), translate("Directory"));
 		else if (UI.getInstance().getAssistantDialog().isVisible())
-			popup = new DirectoryPopupWindow(UI.getInstance().getAssistantDialog(), _("Directory"));
+			popup = new DirectoryPopupWindow(UI.getInstance().getAssistantDialog(), translate("Directory"));
 		popup.setVisible(true);
 
 		if (popup.getButtonClicked() == DirectoryPopupWindow.ButtonClicked.OK) {

--- a/src/org/revager/gui/actions/meeting/AddMeetingAction.java
+++ b/src/org/revager/gui/actions/meeting/AddMeetingAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.meeting;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
@@ -43,7 +43,7 @@ public class AddMeetingAction extends AbstractAction {
 		super();
 
 		putValue(SMALL_ICON, Data.getInstance().getIcon("menuNewMeet_16x16.png"));
-		putValue(NAME, _("Add Meeting"));
+		putValue(NAME, translate("Add Meeting"));
 		putValue(ACCELERATOR_KEY,
 				KeyStroke.getKeyStroke(KeyEvent.VK_I, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 	}

--- a/src/org/revager/gui/actions/meeting/CommentMeetingAction.java
+++ b/src/org/revager/gui/actions/meeting/CommentMeetingAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.meeting;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 
@@ -58,7 +58,7 @@ public class CommentMeetingAction extends AbstractAction {
 		}
 
 		TextPopupWindow popup = new TextPopupWindow(UI.getInstance().getMainFrame(),
-				_("Comments on the selected meeting:"), comments, true);
+				translate("Comments on the selected meeting:"), comments, true);
 
 		popup.setVisible(true);
 

--- a/src/org/revager/gui/actions/severities/AddSeverityAction.java
+++ b/src/org/revager/gui/actions/severities/AddSeverityAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.severities;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 
@@ -42,7 +42,7 @@ public class AddSeverityAction extends AbstractAction {
 	 */
 	@Override
 	public void actionPerformed(ActionEvent ev) {
-		String placeHolder = _("New severity");
+		String placeHolder = translate("New severity");
 
 		Application.getInstance().getSeverityMgmt().addSeverity(placeHolder);
 

--- a/src/org/revager/gui/actions/severities/RemoveSeverityAction.java
+++ b/src/org/revager/gui/actions/severities/RemoveSeverityAction.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.actions.severities;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.event.ActionEvent;
 
@@ -36,7 +36,7 @@ import org.revager.gui.dialogs.WarningDialog.ButtonClicked;
 @SuppressWarnings("serial")
 public class RemoveSeverityAction extends AbstractAction {
 
-	private String message = _(
+	private String message = translate(
 			"If you remove a severity, this will affect the whole review. Removed severities will be replaced by the next higher one. Would you really like to remove the selected severity?");
 
 	/*

--- a/src/org/revager/gui/aspects_manager/AspectsManagerFrame.java
+++ b/src/org/revager/gui/aspects_manager/AspectsManagerFrame.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.aspects_manager;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -124,7 +124,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 	private int dividerLocation = 0;
 
 	private CheckboxTree tree;
-	private CheckNode root = new CheckNode(_("All catalogs"));
+	private CheckNode root = new CheckNode(translate("All catalogs"));
 	private DefaultTreeModel dtm = new DefaultTreeModel(root);
 
 	private AspectTableModel aspTabModel;
@@ -179,7 +179,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		JButton tbConfirm = GUITools.newImageButton();
 		tbConfirm.setIcon(Data.getInstance().getIcon("confirm_50x50_0.png"));
 		tbConfirm.setRolloverIcon(Data.getInstance().getIcon("confirm_50x50.png"));
-		tbConfirm.setToolTipText(_("Confirm and close Aspects Manager"));
+		tbConfirm.setToolTipText(translate("Confirm and close Aspects Manager"));
 		tbConfirm.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -196,7 +196,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		tbAddCatalog = GUITools.newImageButton();
 		tbAddCatalog.setIcon(Data.getInstance().getIcon("addCatalog_50x50_0.png"));
 		tbAddCatalog.setRolloverIcon(Data.getInstance().getIcon("addCatalog_50x50.png"));
-		tbAddCatalog.setToolTipText(_("Add Catalog"));
+		tbAddCatalog.setToolTipText(translate("Add Catalog"));
 		tbAddCatalog.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -214,7 +214,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 					}
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 			}
 		});
@@ -223,7 +223,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		tbCopyCatalog = GUITools.newImageButton();
 		tbCopyCatalog.setIcon(Data.getInstance().getIcon("copyCatalog_50x50_0.png"));
 		tbCopyCatalog.setRolloverIcon(Data.getInstance().getIcon("copyCatalog_50x50.png"));
-		tbCopyCatalog.setToolTipText(_("Copy selected Catalog"));
+		tbCopyCatalog.setToolTipText(translate("Copy selected Catalog"));
 		tbCopyCatalog.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -241,7 +241,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 					updateTree(catalog, null, null);
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 			}
 		});
@@ -250,14 +250,14 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		tbAddAspect = GUITools.newImageButton();
 		tbAddAspect.setIcon(Data.getInstance().getIcon("addAspect_50x50_0.png"));
 		tbAddAspect.setRolloverIcon(Data.getInstance().getIcon("addAspect_50x50.png"));
-		tbAddAspect.setToolTipText(_("Add a new Aspect to the selected Catalog"));
+		tbAddAspect.setToolTipText(translate("Add a new Aspect to the selected Catalog"));
 		tbAddAspect.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				AppCatalog catalog = getSelectedCatalog();
 				AppAspect selAsp = getSelectedAspect();
 
-				String category = _("(No Category)");
+				String category = translate("(No Category)");
 
 				try {
 					if (catalog == null && selAsp != null) {
@@ -280,7 +280,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 					}
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 			}
 		});
@@ -288,7 +288,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		tbNewAttendee = GUITools.newImageButton(Data.getInstance().getIcon("addAttendee_50x50_0.png"),
 				Data.getInstance().getIcon("addAttendee_50x50.png"));
-		tbNewAttendee.setToolTipText(_("Add Attendee"));
+		tbNewAttendee.setToolTipText(translate("Add Attendee"));
 		tbNewAttendee.addActionListener(ActionRegistry.getInstance().get(AddAttendeeAction.class.getName()));
 		tbNewAttendee.addActionListener(new ActionListener() {
 			@Override
@@ -304,7 +304,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		tbRemove = GUITools.newImageButton();
 		tbRemove.setIcon(Data.getInstance().getIcon("remove_50x50_0.png"));
 		tbRemove.setRolloverIcon(Data.getInstance().getIcon("remove_50x50.png"));
-		tbRemove.setToolTipText(_("Remove selected Item"));
+		tbRemove.setToolTipText(translate("Remove selected Item"));
 		tbRemove.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -322,7 +322,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 					}
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 
 				updateTree();
@@ -333,7 +333,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		tbRemoveAll = GUITools.newImageButton();
 		tbRemoveAll.setIcon(Data.getInstance().getIcon("removeAll_50x50_0.png"));
 		tbRemoveAll.setRolloverIcon(Data.getInstance().getIcon("removeAll_50x50.png"));
-		tbRemoveAll.setToolTipText(_("Remove selected Items"));
+		tbRemoveAll.setToolTipText(translate("Remove selected Items"));
 		tbRemoveAll.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -362,7 +362,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 							}
 						} catch (DataException exc) {
 							JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
-									GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+									GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 						}
 
 						notifySwitchToEditMode();
@@ -388,7 +388,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		tbEditItem = GUITools.newImageButton();
 		tbEditItem.setIcon(Data.getInstance().getIcon("editItem_50x50_0.png"));
 		tbEditItem.setRolloverIcon(Data.getInstance().getIcon("editItem_50x50.png"));
-		tbEditItem.setToolTipText(_("Edit selected Item"));
+		tbEditItem.setToolTipText(translate("Edit selected Item"));
 		tbEditItem.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -403,7 +403,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 					popup.setVisible(true);
 				} else if (selCategory != null) {
-					TextPopupWindow popup = new TextPopupWindow(aspMan, _("Please enter a name for the category."),
+					TextPopupWindow popup = new TextPopupWindow(aspMan, translate("Please enter a name for the category."),
 							selCategory, false);
 
 					popup.setVisible(true);
@@ -416,7 +416,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 							updateTree(selCatalog, newCategory, null, selCategory);
 						} catch (DataException exc) {
-							JOptionPane.showMessageDialog(aspMan, GUITools.getMessagePane(exc.getMessage()), _("Error"),
+							JOptionPane.showMessageDialog(aspMan, GUITools.getMessagePane(exc.getMessage()), translate("Error"),
 									JOptionPane.ERROR_MESSAGE);
 						}
 					}
@@ -431,7 +431,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		tbAutoAllocation = GUITools.newImageButton(Data.getInstance().getIcon("autoAllocation_50x50_0.png"),
 				Data.getInstance().getIcon("autoAllocation_50x50.png"));
-		tbAutoAllocation.setToolTipText(_("Assign selected Aspects to the Reviewers automatically"));
+		tbAutoAllocation.setToolTipText(translate("Assign selected Aspects to the Reviewers automatically"));
 		tbAutoAllocation.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -443,7 +443,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		tbImportCatalog = GUITools.newImageButton(Data.getInstance().getIcon("importCatalog_50x50_0.png"),
 				Data.getInstance().getIcon("importCatalog_50x50.png"));
-		tbImportCatalog.setToolTipText(_("Import Catalog"));
+		tbImportCatalog.setToolTipText(translate("Import Catalog"));
 		tbImportCatalog.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -462,7 +462,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		tbExportCatalog = GUITools.newImageButton(Data.getInstance().getIcon("exportCatalog_50x50_0.png"),
 				Data.getInstance().getIcon("exportCatalog_50x50.png"));
-		tbExportCatalog.setToolTipText(_("Export selected Catalog"));
+		tbExportCatalog.setToolTipText(translate("Export selected Catalog"));
 		tbExportCatalog.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -484,7 +484,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		tbImportAspects = GUITools.newImageButton(Data.getInstance().getIcon("importAspects_50x50_0.png"),
 				Data.getInstance().getIcon("importAspects_50x50.png"));
-		tbImportAspects.setToolTipText(_("Import Aspects into the selected Catalog"));
+		tbImportAspects.setToolTipText(translate("Import Aspects into the selected Catalog"));
 		tbImportAspects.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -507,7 +507,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		tbExportAspects = GUITools.newImageButton(Data.getInstance().getIcon("exportAspects_50x50_0.png"),
 				Data.getInstance().getIcon("exportAspects_50x50.png"));
-		tbExportAspects.setToolTipText(_("Export selected Aspects"));
+		tbExportAspects.setToolTipText(translate("Export selected Aspects"));
 		tbExportAspects.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -529,7 +529,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		tbLoadStdCatalogs = GUITools.newImageButton(Data.getInstance().getIcon("loadStdCatalogs_50x50_0.png"),
 				Data.getInstance().getIcon("loadStdCatalogs_50x50.png"));
-		tbLoadStdCatalogs.setToolTipText(_("Load Standard Catalogs"));
+		tbLoadStdCatalogs.setToolTipText(translate("Load Standard Catalogs"));
 		tbLoadStdCatalogs.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -573,7 +573,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 					try {
 						return GUITools.getTextAsHtml("<b>" + cat.getName() + "</b>\n(" + cat.getNumberOfAspects() + " "
-								+ _("Aspects") + ")" + "\n\n" + cat.getDescription());
+								+ translate("Aspects") + ")" + "\n\n" + cat.getDescription());
 					} catch (DataException e) {
 						return null;
 					}
@@ -631,7 +631,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		pushTop = GUITools.newImageButton(Data.getInstance().getIcon("pushTop_25x25_0.png"),
 				Data.getInstance().getIcon("pushTop_25x25.png"));
-		pushTop.setToolTipText(_("Push Item to the top"));
+		pushTop.setToolTipText(translate("Push Item to the top"));
 		pushTop.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -649,7 +649,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 					}
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 
 				updateTree();
@@ -659,7 +659,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		pushUp = GUITools.newImageButton(Data.getInstance().getIcon("upArrow_25x25_0.png"),
 				Data.getInstance().getIcon("upArrow_25x25.png"));
-		pushUp.setToolTipText(_("Push Item up"));
+		pushUp.setToolTipText(translate("Push Item up"));
 		pushUp.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -677,7 +677,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 					}
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 
 				updateTree();
@@ -687,7 +687,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		pushDown = GUITools.newImageButton(Data.getInstance().getIcon("downArrow_25x25_0.png"),
 				Data.getInstance().getIcon("downArrow_25x25.png"));
-		pushDown.setToolTipText(_("Push Item down"));
+		pushDown.setToolTipText(translate("Push Item down"));
 		pushDown.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -705,7 +705,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 					}
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 
 				updateTree();
@@ -715,7 +715,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		pushBottom = GUITools.newImageButton(Data.getInstance().getIcon("pushBottom_25x25_0.png"),
 				Data.getInstance().getIcon("pushBottom_25x25.png"));
-		pushBottom.setToolTipText(_("Push Item to the bottom"));
+		pushBottom.setToolTipText(translate("Push Item to the bottom"));
 		pushBottom.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -733,7 +733,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 					}
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 
 				updateTree();
@@ -754,14 +754,14 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		 */
 		JButton buttonSort = GUITools.newImageButton(Data.getInstance().getIcon("sort_22x22_0.png"),
 				Data.getInstance().getIcon("sort_22x22.png"));
-		buttonSort.setToolTipText(_("Sort Catalogs in ABC order"));
+		buttonSort.setToolTipText(translate("Sort Catalogs in ABC order"));
 		buttonSort.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				try {
 					Data.getInstance().getAppData().sortCatalogsAlphabetical();
 				} catch (DataException exc) {
-					JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), _("Error"),
+					JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), translate("Error"),
 							JOptionPane.ERROR_MESSAGE);
 				}
 
@@ -775,7 +775,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		 */
 		JButton buttonExpandAll = GUITools.newImageButton(Data.getInstance().getIcon("expandTree_25x25_0.png"),
 				Data.getInstance().getIcon("expandTree_25x25.png"));
-		buttonExpandAll.setToolTipText(_("Expand whole tree"));
+		buttonExpandAll.setToolTipText(translate("Expand whole tree"));
 		buttonExpandAll.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -786,7 +786,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		JButton buttonCollapseAll = GUITools.newImageButton(Data.getInstance().getIcon("collapseTree_25x25_0.png"),
 				Data.getInstance().getIcon("collapseTree_25x25.png"));
-		buttonCollapseAll.setToolTipText(_("Collapse whole tree"));
+		buttonCollapseAll.setToolTipText(translate("Collapse whole tree"));
 		buttonCollapseAll.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -817,9 +817,9 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		GridBagLayout gblView = new GridBagLayout();
 		final JPanel panelView = new JPanel(gblView);
 
-		rbReviewersView = new JRadioButton(_("Show Reviewers"), Data.getInstance().getIcon("reviewers_16x16.png"));
+		rbReviewersView = new JRadioButton(translate("Show Reviewers"), Data.getInstance().getIcon("reviewers_16x16.png"));
 
-		rbAspectsView = new JRadioButton(_("Show assigned Aspects"), Data.getInstance().getIcon("aspects_16x16.png"));
+		rbAspectsView = new JRadioButton(translate("Show assigned Aspects"), Data.getInstance().getIcon("aspects_16x16.png"));
 
 		rbReviewersView.setFont(UI.STANDARD_FONT.deriveFont(Font.BOLD));
 		rbReviewersView.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
@@ -886,7 +886,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		 */
 		buttonAllocAll = GUITools.newImageButton(Data.getInstance().getIcon("allocAspAll_32x32_0.png"),
 				Data.getInstance().getIcon("allocAspAll_32x32.png"));
-		buttonAllocAll.setToolTipText(_("Assign selected Aspects to all Reviewers"));
+		buttonAllocAll.setToolTipText(translate("Assign selected Aspects to all Reviewers"));
 		buttonAllocAll.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -898,7 +898,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 						SwingUtilities.invokeLater(new Runnable() {
 							@Override
 							public void run() {
-								switchToProgressMode(_("Allocating aspects ..."));
+								switchToProgressMode(translate("Allocating aspects ..."));
 							}
 						});
 
@@ -913,7 +913,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 								}
 							}
 						} catch (DataException exc) {
-							JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), _("Error"),
+							JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), translate("Error"),
 									JOptionPane.ERROR_MESSAGE);
 						}
 
@@ -924,7 +924,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 						SwingUtilities.invokeLater(new Runnable() {
 							@Override
 							public void run() {
-								setStatusMessage(_("Aspects allocated successfully."), false);
+								setStatusMessage(translate("Aspects allocated successfully."), false);
 
 								switchToEditMode();
 							}
@@ -955,7 +955,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		 */
 		buttonAlloc = GUITools.newImageButton(Data.getInstance().getIcon("allocAsp_32x32_0.png"),
 				Data.getInstance().getIcon("allocAsp_32x32.png"));
-		buttonAlloc.setToolTipText(_("Assign selected Aspects to the displayed Reviewer"));
+		buttonAlloc.setToolTipText(translate("Assign selected Aspects to the displayed Reviewer"));
 		buttonAlloc.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -967,7 +967,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 						SwingUtilities.invokeLater(new Runnable() {
 							@Override
 							public void run() {
-								switchToProgressMode(_("Allocating aspects ..."));
+								switchToProgressMode(translate("Allocating aspects ..."));
 							}
 						});
 
@@ -978,7 +978,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 								attMgmt.addAspect(asp.getAsResiAspect(), selectedReviewer);
 							}
 						} catch (DataException exc) {
-							JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), _("Error"),
+							JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), translate("Error"),
 									JOptionPane.ERROR_MESSAGE);
 						}
 
@@ -989,7 +989,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 						SwingUtilities.invokeLater(new Runnable() {
 							@Override
 							public void run() {
-								setStatusMessage(_("Aspects allocated successfully."), false);
+								setStatusMessage(translate("Aspects allocated successfully."), false);
 
 								switchToEditMode();
 							}
@@ -1190,7 +1190,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 	public AspectsManagerFrame(Frame parent) {
 		super();
 
-		setTitle(_("Aspects Manager"));
+		setTitle(translate("Aspects Manager"));
 		getContentPane().setLayout(new BorderLayout());
 
 		setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
@@ -1253,7 +1253,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 
 		setLocationToCenter();
 
-		setStatusMessage(_("Aspects Manager loaded successfully."), false);
+		setStatusMessage(translate("Aspects Manager loaded successfully."), false);
 
 		setLayout(new BorderLayout());
 
@@ -1317,7 +1317,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 					GUITools.executeSwingWorker(new LoadDefCatalogsWorker());
 				}
 			} catch (DataException e) {
-				JOptionPane.showMessageDialog(this, GUITools.getMessagePane(e.getMessage()), _("Error"),
+				JOptionPane.showMessageDialog(this, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 						JOptionPane.ERROR_MESSAGE);
 			}
 
@@ -1493,7 +1493,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 			 */
 			updateToolBar();
 		} catch (DataException e) {
-			JOptionPane.showMessageDialog(this, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(this, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 	}
@@ -1571,19 +1571,19 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 	 * Creates the hints.
 	 */
 	private void createHints() {
-		hintMinOneAsp = new HintItem(_("You have to assign at least one aspect to a reviewer."), HintItem.WARNING,
+		hintMinOneAsp = new HintItem(translate("You have to assign at least one aspect to a reviewer."), HintItem.WARNING,
 				"aspects_management");
 
 		hintMinOneRev = new HintItem(
-				_("In order to assign aspects to reviewers you have to add at least one reviewer to the review."),
+				translate("In order to assign aspects to reviewers you have to add at least one reviewer to the review."),
 				HintItem.WARNING, "aspects_management");
 
 		hintInfoAlloc = new HintItem(
-				_("You can assign catalogs, categories or aspects to the reviewers after selecting them."),
+				translate("You can assign catalogs, categories or aspects to the reviewers after selecting them."),
 				HintItem.INFO, "aspects_management");
 
 		hintInfoImpExp = new HintItem(
-				_("You can import complete catalogs or selected aspects by using the provided buttons in the tool bar."),
+				translate("You can import complete catalogs or selected aspects by using the provided buttons in the tool bar."),
 				HintItem.INFO, "aspects_management");
 	}
 
@@ -1618,7 +1618,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		if (UI.getInstance().getStatus() == UI.Status.NO_FILE_LOADED) {
 			rightPanel.removeAll();
 
-			JLabel labelDesc = GUITools.getMessagePane(_(
+			JLabel labelDesc = GUITools.getMessagePane(translate(
 					"No review is loaded. Therefore you can only work in the library with its catalogs and aspects."));
 			labelDesc.setHorizontalAlignment(SwingConstants.CENTER);
 			labelDesc.setForeground(Color.GRAY);
@@ -1627,7 +1627,7 @@ public class AspectsManagerFrame extends AbstractFrame implements Observer {
 		} else if (!existReviewers()) {
 			rightPanel.removeAll();
 
-			JLabel labelDesc = GUITools.getMessagePane(_(
+			JLabel labelDesc = GUITools.getMessagePane(translate(
 					"There aren't any reviewers existing in the review. After adding at least one reviewer by using the 'Add Attendee' button you can assign them aspects from the existing catalogs."));
 			labelDesc.setHorizontalAlignment(SwingConstants.CENTER);
 			labelDesc.setForeground(Color.GRAY);

--- a/src/org/revager/gui/aspects_manager/EditAspectPopupWindow.java
+++ b/src/org/revager/gui/aspects_manager/EditAspectPopupWindow.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.aspects_manager;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -73,7 +73,7 @@ public class EditAspectPopupWindow extends JDialog {
 		RESI_ASPECT, APP_ASPECT, APP_CATALOG;
 	}
 
-	private static final String STANDARD_CATEGORY = _("(No Category)");
+	private static final String STANDARD_CATEGORY = translate("(No Category)");
 
 	private AspectManagement aspMgmt = Application.getInstance().getAspectMgmt();
 	private ApplicationData appData = Data.getInstance().getAppData();
@@ -150,7 +150,7 @@ public class EditAspectPopupWindow extends JDialog {
 
 		// setUndecorated(true);
 		setResizable(false);
-		setTitle(_("RevAger"));
+		setTitle(translate("RevAger"));
 
 		setModal(true);
 	}
@@ -184,8 +184,8 @@ public class EditAspectPopupWindow extends JDialog {
 		try {
 			switch (mode) {
 			case RESI_ASPECT:
-				title = _("Please enter the required information of the aspect into the provided text fields.");
-				labelTitle.setText(_("Directive of the aspect:"));
+				title = translate("Please enter the required information of the aspect into the provided text fields.");
+				labelTitle.setText(translate("Directive of the aspect:"));
 
 				textFieldTitle.setText(aspect.getDirective());
 				textAreaDescription.setText(aspect.getDescription());
@@ -198,8 +198,8 @@ public class EditAspectPopupWindow extends JDialog {
 
 				break;
 			case APP_ASPECT:
-				title = _("Please enter the required information of the aspect into the provided text fields.");
-				labelTitle.setText(_("Directive of the aspect:"));
+				title = translate("Please enter the required information of the aspect into the provided text fields.");
+				labelTitle.setText(translate("Directive of the aspect:"));
 
 				textFieldTitle.setText(appAspect.getDirective());
 				textAreaDescription.setText(appAspect.getDescription());
@@ -225,8 +225,8 @@ public class EditAspectPopupWindow extends JDialog {
 
 				break;
 			case APP_CATALOG:
-				title = _("Please enter the required information of the catalog into the provided text fields.");
-				labelTitle.setText(_("Name of the catalog:"));
+				title = translate("Please enter the required information of the catalog into the provided text fields.");
+				labelTitle.setText(translate("Name of the catalog:"));
 
 				textFieldTitle.setText(appCatalog.getName());
 				textAreaDescription.setText(appCatalog.getDescription());
@@ -239,7 +239,7 @@ public class EditAspectPopupWindow extends JDialog {
 				break;
 			}
 		} catch (DataException e) {
-			JOptionPane.showMessageDialog(this, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(this, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 
 			return;
@@ -253,9 +253,9 @@ public class EditAspectPopupWindow extends JDialog {
 
 		panelBase.add(textTitle, BorderLayout.NORTH);
 
-		JLabel labelDescription = new JLabel(_("Description:"));
-		JLabel labelCatalog = new JLabel(_("Catalog:"));
-		JLabel labelCategory = new JLabel(_("Category:"));
+		JLabel labelDescription = new JLabel(translate("Description:"));
+		JLabel labelCatalog = new JLabel(translate("Catalog:"));
+		JLabel labelCategory = new JLabel(translate("Category:"));
 
 		int ins = 5;
 
@@ -290,7 +290,7 @@ public class EditAspectPopupWindow extends JDialog {
 		JButton buttonAbort = GUITools.newImageButton();
 		buttonAbort.setIcon(Data.getInstance().getIcon("buttonCancel_24x24_0.png"));
 		buttonAbort.setRolloverIcon(Data.getInstance().getIcon("buttonCancel_24x24.png"));
-		buttonAbort.setToolTipText(_("Abort"));
+		buttonAbort.setToolTipText(translate("Abort"));
 		buttonAbort.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -303,7 +303,7 @@ public class EditAspectPopupWindow extends JDialog {
 		JButton buttonConfirm = GUITools.newImageButton();
 		buttonConfirm.setIcon(Data.getInstance().getIcon("buttonOk_24x24_0.png"));
 		buttonConfirm.setRolloverIcon(Data.getInstance().getIcon("buttonOk_24x24.png"));
-		buttonConfirm.setToolTipText(_("Confirm"));
+		buttonConfirm.setToolTipText(translate("Confirm"));
 		buttonConfirm.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -374,7 +374,7 @@ public class EditAspectPopupWindow extends JDialog {
 					}
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(((JButton) e.getSource()).getParent().getParent(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 
 					return;
 				}

--- a/src/org/revager/gui/aspects_manager/ReviewerPanel.java
+++ b/src/org/revager/gui/aspects_manager/ReviewerPanel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.aspects_manager;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Component;
 import java.awt.GridBagConstraints;
@@ -150,7 +150,7 @@ public class ReviewerPanel extends JPanel implements Observer {
 
 		buttonRemove = GUITools.newImageButton(Data.getInstance().getIcon("remove_25x25_0.png"),
 				Data.getInstance().getIcon("remove_25x25.png"));
-		buttonRemove.setToolTipText(_("Remove selected aspect"));
+		buttonRemove.setToolTipText(translate("Remove selected aspect"));
 		buttonRemove.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -174,12 +174,12 @@ public class ReviewerPanel extends JPanel implements Observer {
 
 		buttonEdit = GUITools.newImageButton(Data.getInstance().getIcon("edit_25x25_0.png"),
 				Data.getInstance().getIcon("edit_25x25.png"));
-		buttonEdit.setToolTipText(_("Edit selected aspect"));
+		buttonEdit.setToolTipText(translate("Edit selected aspect"));
 		buttonEdit.addActionListener(editAction);
 
 		buttonPushUp = GUITools.newImageButton(Data.getInstance().getIcon("upArrow_25x25_0.png"),
 				Data.getInstance().getIcon("upArrow_25x25.png"));
-		buttonPushUp.setToolTipText(_("Push up item"));
+		buttonPushUp.setToolTipText(translate("Push up item"));
 		buttonPushUp.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -200,7 +200,7 @@ public class ReviewerPanel extends JPanel implements Observer {
 
 		buttonPushDown = GUITools.newImageButton(Data.getInstance().getIcon("downArrow_25x25_0.png"),
 				Data.getInstance().getIcon("downArrow_25x25.png"));
-		buttonPushDown.setToolTipText(_("Push down item"));
+		buttonPushDown.setToolTipText(translate("Push down item"));
 		buttonPushDown.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/src/org/revager/gui/dialogs/AboutDialog.java
+++ b/src/org/revager/gui/dialogs/AboutDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Cursor;
 import java.awt.Desktop;
@@ -58,7 +58,7 @@ public class AboutDialog extends AbstractDialog {
 	 */
 	public AboutDialog(Frame parent) {
 		super(parent);
-		setTitle(_("About RevAger"));
+		setTitle(translate("About RevAger"));
 		setDescription(null);
 		setIcon(Data.getInstance().getIcon("RevAger_300x74.png"));
 		setLayout(gbl);
@@ -69,15 +69,15 @@ public class AboutDialog extends AbstractDialog {
 		JLabel appNameLbl = new JLabel(Data.getInstance().getResource("appName"));
 		appNameLbl.setFont(fontTitle);
 
-		JLabel versionLbl = new JLabel(_("Version:"));
+		JLabel versionLbl = new JLabel(translate("Version:"));
 		versionLbl.setFont(fontNormal);
-		JLabel buildLbl = new JLabel(_("Build:"));
+		JLabel buildLbl = new JLabel(translate("Build:"));
 		buildLbl.setFont(fontNormal);
-		JLabel releaseLbl = new JLabel(_("Date of Release:"));
+		JLabel releaseLbl = new JLabel(translate("Date of Release:"));
 		releaseLbl.setFont(fontNormal);
-		JLabel homepageLbl = new JLabel(_("Homepage:"));
+		JLabel homepageLbl = new JLabel(translate("Homepage:"));
 		homepageLbl.setFont(fontNormal);
-		JLabel emailLbl = new JLabel(_("E-mail:"));
+		JLabel emailLbl = new JLabel(translate("E-mail:"));
 		emailLbl.setFont(fontNormal);
 
 		JLabel appVersionLbl = new JLabel(Data.getInstance().getResource("appVersion"));
@@ -185,7 +185,7 @@ public class AboutDialog extends AbstractDialog {
 		setSize(350, 400);
 		setResizable(false);
 
-		JButton cancel = new JButton(_("Close"), Data.getInstance().getIcon("buttonClose_16x16.png"));
+		JButton cancel = new JButton(translate("Close"), Data.getInstance().getIcon("buttonClose_16x16.png"));
 		cancel.addActionListener(new ActionListener() {
 
 			@Override

--- a/src/org/revager/gui/dialogs/AttendeeDialog.java
+++ b/src/org/revager/gui/dialogs/AttendeeDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Color;
 import java.awt.Container;
@@ -172,7 +172,7 @@ public class AttendeeDialog extends AbstractDialog {
 		try {
 			contactTxtArea.setText(currentAppAttendee.getContact());
 		} catch (DataException e) {
-			JOptionPane.showMessageDialog(this, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(this, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 
@@ -248,36 +248,36 @@ public class AttendeeDialog extends AbstractDialog {
 
 		if (currentAttendee == null) {
 
-			setTitle(_("Add Attendee"));
-			setDescription(_("Here you can manage all required information of the attendee."));
+			setTitle(translate("Add Attendee"));
+			setDescription(translate("Here you can manage all required information of the attendee."));
 			setIcon(Data.getInstance().getIcon("addAttendee_50x50.png"));
 			setHelpChapter("attendees_management", "1");
 
 			nameTxtFld.setText(null);
 			contactTxtArea.setText(null);
-			roleBox.setSelectedItem(_(Role.REVIEWER.toString()));
+			roleBox.setSelectedItem(translate(Role.REVIEWER.toString()));
 
 			if (fromAssistant) {
-				cancelBttn.setText(_("Back"));
+				cancelBttn.setText(translate("Back"));
 				// cancelBttn.setEnabled(false);
 				// closing operation has to be disabled, but how?
 
 			}
 		} else {
-			setTitle(_("Edit Attendee"));
-			setDescription(_("Here you can manage all required information of the attendee."));
+			setTitle(translate("Edit Attendee"));
+			setDescription(translate("Here you can manage all required information of the attendee."));
 			setIcon(Data.getInstance().getIcon("editAttendee_50x50.png"));
 			setHelpChapter("attendees_management", "2");
 
 			nameTxtFld.setText(currentAttendee.getName());
 			contactTxtArea.setText(currentAttendee.getContact());
-			roleBox.setSelectedItem(_(currentAttendee.getRole().toString()));
+			roleBox.setSelectedItem(translate(currentAttendee.getRole().toString()));
 
 			try {
 				currentAppAttendee = Data.getInstance().getAppData().getAttendee(currentAttendee.getName(),
 						currentAttendee.getContact());
 			} catch (DataException e) {
-				JOptionPane.showMessageDialog(this, GUITools.getMessagePane(e.getMessage()), _("Error"),
+				JOptionPane.showMessageDialog(this, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 						JOptionPane.ERROR_MESSAGE);
 			}
 
@@ -311,28 +311,28 @@ public class AttendeeDialog extends AbstractDialog {
 		contentPane = getContentPane();
 		contentPane.setLayout(gbl);
 
-		name = new JLabel(_("Name:"));
+		name = new JLabel(translate("Name:"));
 		nameTxtFld = new JTextField();
 		nameTxtFld.addFocusListener(focusListener);
 
 		directory = GUITools.newImageButton();
 		directory.setIcon(Data.getInstance().getIcon("directory_25x25_0.png"));
 		directory.setRolloverIcon(Data.getInstance().getIcon("directory_25x25.png"));
-		directory.setToolTipText(_("Open Attendee Directory"));
+		directory.setToolTipText(translate("Open Attendee Directory"));
 		directory.addActionListener(ActionRegistry.getInstance().get(SelectAttOutOfDirAction.class.getName()));
-		contact = new JLabel(_("Contact information:"));
+		contact = new JLabel(translate("Contact information:"));
 
 		contactTxtArea = new JTextArea();
 		contactTxtArea.addFocusListener(focusListener);
 		contactScrllPn = GUITools.setIntoScrllPn(contactTxtArea);
 
-		role = new JLabel(_("Role:"));
+		role = new JLabel(translate("Role:"));
 		roleBox = new JComboBox();
 		roleBox.addFocusListener(focusListener);
 
 		for (Role x : Role.values()) {
 			String roleString = x.toString();
-			roleBox.addItem(_(roleString));
+			roleBox.addItem(translate(roleString));
 		}
 
 		roleBox.addItemListener(new ItemListener() {
@@ -342,7 +342,7 @@ public class AttendeeDialog extends AbstractDialog {
 			}
 		});
 
-		strengthLbl = new JLabel(_("Priorities:"));
+		strengthLbl = new JLabel(translate("Priorities:"));
 
 		buttonPanel = new JPanel(new GridLayout(3, 1));
 		strengthTbl = GUITools.newStandardTable(null, false);
@@ -373,12 +373,12 @@ public class AttendeeDialog extends AbstractDialog {
 		addStrength = GUITools.newImageButton();
 		addStrength.setIcon(Data.getInstance().getIcon("add_25x25_0.png"));
 		addStrength.setRolloverIcon(Data.getInstance().getIcon("add_25x25.png"));
-		addStrength.setToolTipText(_("Add Strength"));
+		addStrength.setToolTipText(translate("Add Strength"));
 
 		addStrength.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent ev) {
-				final String title = _("Please select at least one strength for the reviewer:");
+				final String title = translate("Please select at least one strength for the reviewer:");
 
 				SwingWorker<Void, Void> showPopupWorker = new SwingWorker<Void, Void>() {
 					@Override
@@ -397,7 +397,7 @@ public class AttendeeDialog extends AbstractDialog {
 								SwingUtilities.invokeLater(new Runnable() {
 									@Override
 									public void run() {
-										switchToProgressMode(_("Importing catalog ..."));
+										switchToProgressMode(translate("Importing catalog ..."));
 									}
 								});
 
@@ -459,7 +459,7 @@ public class AttendeeDialog extends AbstractDialog {
 		removeStrength = GUITools.newImageButton();
 		removeStrength.setIcon(Data.getInstance().getIcon("remove_25x25_0.png"));
 		removeStrength.setRolloverIcon(Data.getInstance().getIcon("remove_25x25.png"));
-		removeStrength.setToolTipText(_("Remove Strength"));
+		removeStrength.setToolTipText(translate("Remove Strength"));
 		removeStrength.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent ev) {
@@ -500,7 +500,7 @@ public class AttendeeDialog extends AbstractDialog {
 		GUITools.addComponent(contentPane, gbl, buttonPanel, 4, 5, 1, 2, 0, 0, 17, 5, 0, 0, GridBagConstraints.NONE,
 				GridBagConstraints.NORTHWEST);
 
-		cancelBttn = new JButton(_("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
+		cancelBttn = new JButton(translate("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
 		cancelBttn.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent ev) {
@@ -518,7 +518,7 @@ public class AttendeeDialog extends AbstractDialog {
 
 		addButton(cancelBttn);
 
-		confirmBttn = new JButton(_("Confirm"), Data.getInstance().getIcon("buttonOk_16x16.png"));
+		confirmBttn = new JButton(translate("Confirm"), Data.getInstance().getIcon("buttonOk_16x16.png"));
 		confirmBttn.addActionListener(ActionRegistry.getInstance().get(ConfirmAttendeeAction.class.getName()));
 
 		addButton(confirmBttn);
@@ -557,7 +557,7 @@ public class AttendeeDialog extends AbstractDialog {
 		 */
 		boolean enable = false;
 
-		if (((String) roleBox.getSelectedItem()).equals(_(Role.REVIEWER.toString()))) {
+		if (((String) roleBox.getSelectedItem()).equals(translate(Role.REVIEWER.toString()))) {
 			enable = true;
 		}
 

--- a/src/org/revager/gui/dialogs/CSVProfilesDialog.java
+++ b/src/org/revager/gui/dialogs/CSVProfilesDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Component;
 import java.awt.Dimension;
@@ -127,15 +127,15 @@ public class CSVProfilesDialog extends AbstractDialog {
 	public CSVProfilesDialog(Frame parent) {
 		super(parent);
 
-		setTitle(_("CSV Profiles for Finding Export"));
+		setTitle(translate("CSV Profiles for Finding Export"));
 		setIcon(Data.getInstance().getIcon("CSVProfiles_64x64.png"));
-		setDescription(_("Here you can configure the CSV Profiles for exporting findings."));
+		setDescription(translate("Here you can configure the CSV Profiles for exporting findings."));
 
 		setHelpChapter("csv_profiles", "1");
 		/*
 		 * Close button
 		 */
-		JButton buttonClose = new JButton(_("Close"), Data.getInstance().getIcon("buttonClose_16x16.png"));
+		JButton buttonClose = new JButton(translate("Close"), Data.getInstance().getIcon("buttonClose_16x16.png"));
 		buttonClose.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -231,7 +231,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 					}
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(UI.getInstance().getCSVProfilesDialog(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 			}
 		});
@@ -253,7 +253,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 			}
 		});
 
-		GUITools.addComponent(panelContent, gblContent, new JLabel(_("Name of the CSV Profile:")), 0, gblRow, 2, 1, 1.0,
+		GUITools.addComponent(panelContent, gblContent, new JLabel(translate("Name of the CSV Profile:")), 0, gblRow, 2, 1, 1.0,
 				0.0, 0, 5, 0, 5, GridBagConstraints.BOTH, GridBagConstraints.WEST);
 
 		gblRow++;
@@ -315,7 +315,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 			}
 		});
 
-		GUITools.addComponent(panelContent, gblContent, new JLabel(_("Column order in the CSV file:")), 0, gblRow, 4, 1,
+		GUITools.addComponent(panelContent, gblContent, new JLabel(translate("Column order in the CSV file:")), 0, gblRow, 4, 1,
 				1.0, 0.0, 15, 5, 0, 5, GridBagConstraints.BOTH, GridBagConstraints.WEST);
 
 		gblRow++;
@@ -357,7 +357,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 		textColumn4 = new JTextField();
 		textColumn4.addFocusListener(textColFocusListener);
 
-		GUITools.addComponent(panelContent, gblContent, new JLabel(_("Column names in the CSV file:")), 0, gblRow, 4, 1,
+		GUITools.addComponent(panelContent, gblContent, new JLabel(translate("Column names in the CSV file:")), 0, gblRow, 4, 1,
 				1.0, 0.0, 15, 5, 0, 5, GridBagConstraints.BOTH, GridBagConstraints.WEST);
 
 		gblRow++;
@@ -383,10 +383,10 @@ public class CSVProfilesDialog extends AbstractDialog {
 			}
 		};
 
-		boxColsInFirstLine = new JCheckBox(_("Put the given column names into the CSV file (first row)."));
+		boxColsInFirstLine = new JCheckBox(translate("Put the given column names into the CSV file (first row)."));
 		boxColsInFirstLine.addChangeListener(boxChangeListener);
 
-		boxEncapsContent = new JCheckBox(_("Protect the content of individual cells in the CSV file with quotes."));
+		boxEncapsContent = new JCheckBox(translate("Protect the content of individual cells in the CSV file with quotes."));
 		boxEncapsContent.addChangeListener(boxChangeListener);
 
 		GUITools.addComponent(panelContent, gblContent, boxColsInFirstLine, 0, gblRow, 4, 1, 1.0, 0.0, 25, 5, 5, 5,
@@ -435,7 +435,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 		}
 
 		GUITools.addComponent(panelContent, gblContent,
-				new JLabel(_("Valid severities of the findings for this profile:")), 0, gblRow, 4, 1, 1.0, 0.0, 25, 5,
+				new JLabel(translate("Valid severities of the findings for this profile:")), 0, gblRow, 4, 1, 1.0, 0.0, 25, 5,
 				0, 5, GridBagConstraints.BOTH, GridBagConstraints.WEST);
 
 		gblRow++;
@@ -462,7 +462,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 		/*
 		 * Build content pane with vertical separator
 		 */
-		GUITools.addComponent(getContentPane(), gblBase, new JLabel(_("CSV Profile:")), 0, 0, 2, 1, 1.0, 0.0, 0, 0, 5,
+		GUITools.addComponent(getContentPane(), gblBase, new JLabel(translate("CSV Profile:")), 0, 0, 2, 1, 1.0, 0.0, 0, 0, 5,
 				5, GridBagConstraints.BOTH, GridBagConstraints.WEST);
 
 		JScrollPane scrollList = new JScrollPane(listProfiles, ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
@@ -478,12 +478,12 @@ public class CSVProfilesDialog extends AbstractDialog {
 		 */
 		buttonAdd = GUITools.newImageButton(Data.getInstance().getIcon("add_25x25_0.png"),
 				Data.getInstance().getIcon("add_25x25.png"));
-		buttonAdd.setToolTipText(_("Add a new CSV Profile"));
+		buttonAdd.setToolTipText(translate("Add a new CSV Profile"));
 		buttonAdd.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				TextPopupWindow popup = new TextPopupWindow(UI.getInstance().getCSVProfilesDialog(),
-						_("Please enter a name for the new CSV Profile:"), null, false);
+						translate("Please enter a name for the new CSV Profile:"), null, false);
 
 				popup.setVisible(true);
 
@@ -494,7 +494,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 						GUITools.executeSwingWorker(new CSVProfilesWorker(popup.getInput()));
 					} catch (DataException exc) {
 						JOptionPane.showMessageDialog(UI.getInstance().getCSVProfilesDialog(),
-								GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+								GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 					}
 				}
 			}
@@ -502,11 +502,11 @@ public class CSVProfilesDialog extends AbstractDialog {
 
 		buttonRemove = GUITools.newImageButton(Data.getInstance().getIcon("remove_25x25_0.png"),
 				Data.getInstance().getIcon("remove_25x25.png"));
-		buttonRemove.setToolTipText(_("Remove selected CSV Profile"));
+		buttonRemove.setToolTipText(translate("Remove selected CSV Profile"));
 		buttonRemove.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				Object[] options = { _("Remove"), _("Cancel") };
+				Object[] options = { translate("Remove"), translate("Cancel") };
 
 				String profName = (String) listProfiles.getSelectedValue();
 
@@ -514,9 +514,9 @@ public class CSVProfilesDialog extends AbstractDialog {
 					if (appData.getNumberOfCSVProfiles() > 1
 							&& JOptionPane.showOptionDialog(UI.getInstance().getCSVProfilesDialog(),
 									GUITools.getMessagePane(
-											_("You are going to delete the selected CSV Profile. Do you really want to continue?")
+											translate("You are going to delete the selected CSV Profile. Do you really want to continue?")
 													+ "\n\n" + profName),
-									_("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null,
+									translate("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE, null,
 									options, options[0]) == JOptionPane.YES_OPTION) {
 
 						appData.removeCSVProfile(profName);
@@ -525,7 +525,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 					}
 				} catch (DataException exc) {
 					JOptionPane.showMessageDialog(UI.getInstance().getCSVProfilesDialog(),
-							GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 			}
 		});
@@ -839,7 +839,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 				}
 			} catch (DataException e) {
 				JOptionPane.showMessageDialog(UI.getInstance().getCSVProfilesDialog(),
-						GUITools.getMessagePane(e.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+						GUITools.getMessagePane(e.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 			}
 
 			updatingAppData = false;
@@ -860,7 +860,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 			}
 		} catch (DataException exc) {
 			JOptionPane.showMessageDialog(UI.getInstance().getCSVProfilesDialog(),
-					GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+					GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 		}
 
 		return vecProfiles;
@@ -884,7 +884,7 @@ public class CSVProfilesDialog extends AbstractDialog {
 				updateDialog(appData.getCSVProfiles().get(0));
 			} catch (DataException exc) {
 				JOptionPane.showMessageDialog(UI.getInstance().getCSVProfilesDialog(),
-						GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+						GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 			}
 
 			dialogContentCreated = true;

--- a/src/org/revager/gui/dialogs/CreateInvitationsDialog.java
+++ b/src/org/revager/gui/dialogs/CreateInvitationsDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Color;
 import java.awt.Container;
@@ -188,7 +188,7 @@ public class CreateInvitationsDialog extends AbstractDialog {
 			allAttendeesBx.add(attendee);
 			String roleString = attMgmt.getAttendees().get(index).getRole().toString();
 
-			String attendeeName = attMgmt.getAttendees().get(index).getName() + ", " + _(roleString);
+			String attendeeName = attMgmt.getAttendees().get(index).getName() + ", " + translate(roleString);
 
 			int endIndex = 23;
 			if (attendeeName.length() - 1 < endIndex) {
@@ -228,7 +228,7 @@ public class CreateInvitationsDialog extends AbstractDialog {
 			attPanel.add(attendee);
 		}
 
-		JLabel meetingLbl = new JLabel(_("Selected meeting:"));
+		JLabel meetingLbl = new JLabel(translate("Selected meeting:"));
 
 		meetingsBx = new JComboBox();
 		for (Meeting meet : Application.getInstance().getMeetingMgmt().getMeetings()) {
@@ -239,20 +239,20 @@ public class CreateInvitationsDialog extends AbstractDialog {
 		}
 
 		productBx = new JCheckBox();
-		productBx.setText(_("Attach product to invitation packages"));
+		productBx.setText(translate("Attach product to invitation packages"));
 
 		JPanel rbPanel = new JPanel(new GridLayout(3, 1));
 
 		ButtonGroup buttonG = new ButtonGroup();
-		pdfRB = new JRadioButton(_("Package as PDF file"), true);
+		pdfRB = new JRadioButton(translate("Package as PDF file"), true);
 		rbPanel.add(pdfRB);
 		buttonG.add(pdfRB);
 
-		zipRB = new JRadioButton(_("Package as ZIP file"));
+		zipRB = new JRadioButton(translate("Package as ZIP file"));
 		rbPanel.add(zipRB);
 		buttonG.add(zipRB);
 
-		dirRB = new JRadioButton(_("Package as sub directory"));
+		dirRB = new JRadioButton(translate("Package as sub directory"));
 		rbPanel.add(dirRB);
 		buttonG.add(dirRB);
 
@@ -262,9 +262,9 @@ public class CreateInvitationsDialog extends AbstractDialog {
 		scrllPn.setPreferredSize(new Dimension(230, 300));
 		scrllPn.setMinimumSize(new Dimension(230, 300));
 
-		JLabel attendeeLbl = new JLabel(_("Attendees:"));
+		JLabel attendeeLbl = new JLabel(translate("Attendees:"));
 
-		selectAll = new JToggleButton(_("Select All"));
+		selectAll = new JToggleButton(translate("Select All"));
 		selectAll.setFocusable(false);
 		selectAll.addItemListener(new ItemListener() {
 
@@ -291,11 +291,11 @@ public class CreateInvitationsDialog extends AbstractDialog {
 			}
 		});
 
-		JLabel directory = new JLabel(_("Directory:"));
+		JLabel directory = new JLabel(translate("Directory:"));
 		pathTxtFld = new JTextField();
 		JButton browse = GUITools.newImageButton(Data.getInstance().getIcon("buttonBrowse_22x22_0.png"),
 				Data.getInstance().getIcon("buttonBrowse_22x22.png"));
-		browse.setToolTipText(_("Select directory where to store the packages"));
+		browse.setToolTipText(translate("Select directory where to store the packages"));
 		browse.setMargin(new Insets(1, 1, 1, 1));
 		browse.addActionListener(new ActionListener() {
 
@@ -353,15 +353,15 @@ public class CreateInvitationsDialog extends AbstractDialog {
 
 		pack();
 
-		setTitle(_("Create Invitations"));
-		setDescription(_("Here you can create invitations for the attendees."));
+		setTitle(translate("Create Invitations"));
+		setDescription(translate("Here you can create invitations for the attendees."));
 		setIcon(Data.getInstance().getIcon("createInvitations_64x64.png"));
 
 		setHelpChapter("invitations_management", "1");
 		c.setLayout(gbl);
 		clearInvitationsDialog();
 
-		JButton cancel = new JButton(_("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
+		JButton cancel = new JButton(translate("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -371,7 +371,7 @@ public class CreateInvitationsDialog extends AbstractDialog {
 
 		addButton(cancel);
 
-		JButton confirm = new JButton(_("Confirm"), Data.getInstance().getIcon("buttonOk_16x16.png"));
+		JButton confirm = new JButton(translate("Confirm"), Data.getInstance().getIcon("buttonOk_16x16.png"));
 		confirm.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/src/org/revager/gui/dialogs/EditProductDialog.java
+++ b/src/org/revager/gui/dialogs/EditProductDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Desktop;
@@ -80,10 +80,10 @@ public class EditProductDialog extends AbstractDialog {
 	private JPanel buttonPanel = new JPanel(new GridLayout(4, 1));
 	private JPanel buttonPanelD = new JPanel(new GridLayout(4, 1));
 
-	private JLabel referenceLbl = new JLabel(_("Product reference(s):"));
-	private JLabel dataLbl = new JLabel(_("Product file(s):"));
-	private JLabel nameLbl = new JLabel(_("Product name:"));
-	private JLabel versionLbl = new JLabel(_("Product version:"));
+	private JLabel referenceLbl = new JLabel(translate("Product reference(s):"));
+	private JLabel dataLbl = new JLabel(translate("Product file(s):"));
+	private JLabel nameLbl = new JLabel(translate("Product name:"));
+	private JLabel versionLbl = new JLabel(translate("Product version:"));
 
 	private ReferenceTableModel rtm = new ReferenceTableModel();
 	private ReviewManagement reviewMgmt = Application.getInstance().getReviewMgmt();
@@ -204,7 +204,7 @@ public class EditProductDialog extends AbstractDialog {
 		addReference = GUITools.newImageButton();
 		addReference.setIcon(Data.getInstance().getIcon("add_25x25_0.png"));
 		addReference.setRolloverIcon(Data.getInstance().getIcon("add_25x25.png"));
-		addReference.setToolTipText(_("Add Reference"));
+		addReference.setToolTipText(translate("Add Reference"));
 		addReference.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -212,7 +212,7 @@ public class EditProductDialog extends AbstractDialog {
 					referenceTbl.getCellEditor().stopCellEditing();
 				}
 
-				String placeHolder = _("New reference");
+				String placeHolder = translate("New reference");
 
 				reviewMgmt.removeProductReference(placeHolder);
 				reviewMgmt.addProductReference(placeHolder);
@@ -232,7 +232,7 @@ public class EditProductDialog extends AbstractDialog {
 		removeReference = GUITools.newImageButton();
 		removeReference.setIcon(Data.getInstance().getIcon("remove_25x25_0.png"));
 		removeReference.setRolloverIcon(Data.getInstance().getIcon("remove_25x25.png"));
-		removeReference.setToolTipText(_("Remove Reference"));
+		removeReference.setToolTipText(translate("Remove Reference"));
 		removeReference.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -249,7 +249,7 @@ public class EditProductDialog extends AbstractDialog {
 		editReference = GUITools.newImageButton();
 		editReference.setIcon(Data.getInstance().getIcon("edit_25x25_0.png"));
 		editReference.setRolloverIcon(Data.getInstance().getIcon("edit_25x25.png"));
-		editReference.setToolTipText(_("Edit Reference"));
+		editReference.setToolTipText(translate("Edit Reference"));
 		editReference.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -278,7 +278,7 @@ public class EditProductDialog extends AbstractDialog {
 						Desktop.getDesktop().open(ref);
 					} catch (Exception exc) {
 						JOptionPane.showMessageDialog(UI.getInstance().getEditProductDialog(),
-								GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+								GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 					}
 				}
 			}
@@ -303,7 +303,7 @@ public class EditProductDialog extends AbstractDialog {
 		addData = GUITools.newImageButton();
 		addData.setIcon(Data.getInstance().getIcon("add_25x25_0.png"));
 		addData.setRolloverIcon(Data.getInstance().getIcon("add_25x25.png"));
-		addData.setToolTipText(_("Add File"));
+		addData.setToolTipText(translate("Add File"));
 		addData.addFocusListener(focusListener);
 		addData.addActionListener(new ActionListener() {
 			@Override
@@ -323,7 +323,7 @@ public class EditProductDialog extends AbstractDialog {
 							SwingUtilities.invokeLater(new Runnable() {
 								@Override
 								public void run() {
-									switchToProgressMode(_("Adding file ..."));
+									switchToProgressMode(translate("Adding file ..."));
 								}
 							});
 
@@ -366,7 +366,7 @@ public class EditProductDialog extends AbstractDialog {
 		removeData = GUITools.newImageButton();
 		removeData.setIcon(Data.getInstance().getIcon("remove_25x25_0.png"));
 		removeData.setRolloverIcon(Data.getInstance().getIcon("remove_25x25.png"));
-		removeData.setToolTipText(_("Remove File"));
+		removeData.setToolTipText(translate("Remove File"));
 		removeData.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -382,7 +382,7 @@ public class EditProductDialog extends AbstractDialog {
 						SwingUtilities.invokeLater(new Runnable() {
 							@Override
 							public void run() {
-								switchToProgressMode(_("Removing file ..."));
+								switchToProgressMode(translate("Removing file ..."));
 							}
 						});
 
@@ -465,25 +465,25 @@ public class EditProductDialog extends AbstractDialog {
 		String version = versionTxtFld.getText();
 
 		if (referenceTbl.isEditing()) {
-			setMessage(_("Press enter to add the reference finally."));
+			setMessage(translate("Press enter to add the reference finally."));
 
 			return;
 		}
 
 		if (name.trim().equals("")) {
-			setMessage(_("Please enter the name of the product."));
+			setMessage(translate("Please enter the name of the product."));
 			nameTxtFld.setBorder(UI.MARKED_BORDER_INLINE);
 			return;
 		}
 
 		if (version.trim().equals("")) {
-			setMessage(_("Please enter the version number of the product."));
+			setMessage(translate("Please enter the version number of the product."));
 			versionTxtFld.setBorder(UI.MARKED_BORDER_INLINE);
 			return;
 		}
 
 		if (size < 1) {
-			setMessage(_("Please enter at least one reference for the product."));
+			setMessage(translate("Please enter at least one reference for the product."));
 			refScrllPn.setBorder(UI.MARKED_BORDER);
 			dataScrllPn.setBorder(UI.MARKED_BORDER);
 			return;
@@ -503,8 +503,8 @@ public class EditProductDialog extends AbstractDialog {
 	public EditProductDialog(Frame parent) {
 		super(parent);
 
-		setTitle(_("Specify the Product"));
-		setDescription(_("Here you can set the name, version and references of the product."));
+		setTitle(translate("Specify the Product"));
+		setDescription(translate("Here you can set the name, version and references of the product."));
 		setIcon(Data.getInstance().getIcon("edit_64x64.png"));
 
 		basePanel.setLayout(gbl);
@@ -515,7 +515,7 @@ public class EditProductDialog extends AbstractDialog {
 
 		createDialog();
 
-		close = new JButton(_("Close"), Data.getInstance().getIcon("buttonClose_16x16.png"));
+		close = new JButton(translate("Close"), Data.getInstance().getIcon("buttonClose_16x16.png"));
 		close.addFocusListener(focusListener);
 		close.addActionListener(new ActionListener() {
 			@Override

--- a/src/org/revager/gui/dialogs/ExportCSVDialog.java
+++ b/src/org/revager/gui/dialogs/ExportCSVDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Color;
 import java.awt.Dimension;
@@ -147,8 +147,8 @@ public class ExportCSVDialog extends AbstractDialog {
 	public ExportCSVDialog(Frame parent) {
 		super(parent);
 
-		setTitle(_("Export Findings into a CSV File"));
-		setDescription(_("Here you can export the findings into a CSV file."));
+		setTitle(translate("Export Findings into a CSV File"));
+		setDescription(translate("Here you can export the findings into a CSV file."));
 		setIcon(Data.getInstance().getIcon("CSVExport_50x50.png"));
 
 		setHelpChapter("findings_management", "5");
@@ -177,7 +177,7 @@ public class ExportCSVDialog extends AbstractDialog {
 		try {
 			csvProfileList = appData.getCSVProfiles();
 		} catch (DataException exc) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 
 			return;
@@ -214,7 +214,7 @@ public class ExportCSVDialog extends AbstractDialog {
 
 		ButtonGroup bttnGrp = new ButtonGroup();
 
-		String compRecStr = _("All findigs of this review");
+		String compRecStr = translate("All findigs of this review");
 		compRevRB = new JRadioButton(compRecStr, true);
 		compRevRB.addItemListener(new ItemListener() {
 			@Override
@@ -227,7 +227,7 @@ public class ExportCSVDialog extends AbstractDialog {
 		});
 		bttnGrp.add(compRevRB);
 
-		String localMeetStr = _("Export findings of a certain meeting only:");
+		String localMeetStr = translate("Export findings of a certain meeting only:");
 		JRadioButton localMeetRB = new JRadioButton(localMeetStr);
 		bttnGrp.add(localMeetRB);
 
@@ -235,8 +235,8 @@ public class ExportCSVDialog extends AbstractDialog {
 		localMeetCoBx.setEnabled(false);
 		reporterTxtFld = new JTextField();
 
-		JLabel reporterLbl = new JLabel(_("Bug Reporter:"));
-		JLabel csvProfileLbl = new JLabel(_("CSV Profile:"));
+		JLabel reporterLbl = new JLabel(translate("Bug Reporter:"));
+		JLabel csvProfileLbl = new JLabel(translate("CSV Profile:"));
 
 		GUITools.addComponent(this, gbl, compRevRB, 0, 0, 1, 1, 1.0, 0, 10, 10, 0, 10, GridBagConstraints.HORIZONTAL,
 				GridBagConstraints.NORTHWEST);
@@ -256,7 +256,7 @@ public class ExportCSVDialog extends AbstractDialog {
 		GUITools.addComponent(this, gbl, sevScrllPn, 0, 7, 1, 1, 1.0, 1.0, 5, 10, 0, 10, GridBagConstraints.BOTH,
 				GridBagConstraints.NORTHWEST);
 
-		abortBttn = new JButton(_("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
+		abortBttn = new JButton(translate("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
 		abortBttn.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -264,7 +264,7 @@ public class ExportCSVDialog extends AbstractDialog {
 			}
 		});
 
-		exportBttn = new JButton(_("Export"), Data.getInstance().getIcon("buttonOk_16x16.png"));
+		exportBttn = new JButton(translate("Export"), Data.getInstance().getIcon("buttonOk_16x16.png"));
 		exportBttn.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -285,7 +285,7 @@ public class ExportCSVDialog extends AbstractDialog {
 				if (!profile.getValidSeverityMappings().isEmpty())
 					csvProfileCoBx.addItem(profile.getName());
 			} catch (DataException e) {
-				JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+				JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 						JOptionPane.ERROR_MESSAGE);
 			}
 		}
@@ -313,7 +313,7 @@ public class ExportCSVDialog extends AbstractDialog {
 		try {
 			validSeverityMappingsList = selProfile.getValidSeverityMappings();
 		} catch (DataException e) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 	}

--- a/src/org/revager/gui/dialogs/ExportPDFProtocolDialog.java
+++ b/src/org/revager/gui/dialogs/ExportPDFProtocolDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Dimension;
 import java.awt.Frame;
@@ -114,8 +114,8 @@ public class ExportPDFProtocolDialog extends AbstractDialog {
 	public ExportPDFProtocolDialog(Frame parent) {
 		super(parent);
 
-		setTitle(_("Export Findings as PDF File"));
-		setDescription(_("Here you can export the findings as a PDF file."));
+		setTitle(translate("Export Findings as PDF File"));
+		setDescription(translate("Here you can export the findings as a PDF file."));
 		setIcon(Data.getInstance().getIcon("PDFExport_50x50.png"));
 
 		setHelpChapter("protocol", "9");
@@ -130,18 +130,18 @@ public class ExportPDFProtocolDialog extends AbstractDialog {
 		setLocationToCenter();
 
 		ButtonGroup radioBttnGrp = new ButtonGroup();
-		compRevRB = new JRadioButton(_("All findings of the review"), true);
+		compRevRB = new JRadioButton(translate("All findings of the review"), true);
 		radioBttnGrp.add(compRevRB);
 
-		String fieldsStr = _("Include signing fields for the present attendees.");
-		String addFindRStr = _("Attach files which belong to the findings.");
-		String addProExRefStr = _("Attach file(s) of the product");
+		String fieldsStr = translate("Include signing fields for the present attendees.");
+		String addFindRStr = translate("Attach files which belong to the findings.");
+		String addProExRefStr = translate("Attach file(s) of the product");
 
 		showFieldsChBx = new JCheckBox(fieldsStr);
 		addExFindRefChBx = new JCheckBox(addFindRStr);
 		addExProRefChBx = new JCheckBox(addProExRefStr);
 
-		String locMeetStr = _("Export the findings of a certain meeting only:");
+		String locMeetStr = translate("Export the findings of a certain meeting only:");
 		JRadioButton localMeetRB = new JRadioButton(locMeetStr);
 		localMeetRB.addItemListener(new ItemListener() {
 			@Override
@@ -171,7 +171,7 @@ public class ExportPDFProtocolDialog extends AbstractDialog {
 		GUITools.addComponent(this, gbl, addExFindRefChBx, 0, 5, 1, 1, 1.0, 0, 20, 10, 0, 10,
 				GridBagConstraints.HORIZONTAL, GridBagConstraints.NORTHWEST);
 
-		abortBttn = new JButton(_("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
+		abortBttn = new JButton(translate("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
 		abortBttn.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -179,7 +179,7 @@ public class ExportPDFProtocolDialog extends AbstractDialog {
 			}
 		});
 
-		exportBttn = new JButton(_("Export"), Data.getInstance().getIcon("buttonOk_16x16.png"));
+		exportBttn = new JButton(translate("Export"), Data.getInstance().getIcon("buttonOk_16x16.png"));
 		exportBttn.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/src/org/revager/gui/dialogs/ManageSeveritiesDialog.java
+++ b/src/org/revager/gui/dialogs/ManageSeveritiesDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Container;
 import java.awt.Dimension;
@@ -67,7 +67,7 @@ public class ManageSeveritiesDialog extends AbstractDialog {
 
 	private JTable severityTbl = GUITools.newStandardTable(stm, false);
 
-	private JLabel nameLbl = new JLabel(_("Severities for the findings in this review:"));
+	private JLabel nameLbl = new JLabel(translate("Severities for the findings in this review:"));
 
 	private JPanel buttonPanel = new JPanel(new GridLayout(7, 1));
 
@@ -137,49 +137,49 @@ public class ManageSeveritiesDialog extends AbstractDialog {
 		JButton addSeverity = GUITools.newImageButton();
 		addSeverity.setIcon(Data.getInstance().getIcon("add_25x25_0.png"));
 		addSeverity.setRolloverIcon(Data.getInstance().getIcon("add_25x25.png"));
-		addSeverity.setToolTipText(_("Add Severity"));
+		addSeverity.setToolTipText(translate("Add Severity"));
 		addSeverity.addActionListener(ActionRegistry.getInstance().get(AddSeverityAction.class.getName()));
 		buttonPanel.add(addSeverity);
 
 		removeSeverity = GUITools.newImageButton();
 		removeSeverity.setIcon(Data.getInstance().getIcon("remove_25x25_0.png"));
 		removeSeverity.setRolloverIcon(Data.getInstance().getIcon("remove_25x25.png"));
-		removeSeverity.setToolTipText(_("Remove Severity"));
+		removeSeverity.setToolTipText(translate("Remove Severity"));
 		removeSeverity.addActionListener(ActionRegistry.getInstance().get(RemoveSeverityAction.class.getName()));
 		buttonPanel.add(removeSeverity);
 
 		editSeverity = GUITools.newImageButton();
 		editSeverity.setIcon(Data.getInstance().getIcon("edit_25x25_0.png"));
 		editSeverity.setRolloverIcon(Data.getInstance().getIcon("edit_25x25.png"));
-		editSeverity.setToolTipText(_("Edit Severity"));
+		editSeverity.setToolTipText(translate("Edit Severity"));
 		editSeverity.addActionListener(ActionRegistry.getInstance().get(EditSeverityAction.class.getName()));
 		buttonPanel.add(editSeverity);
 
 		severityTop = GUITools.newImageButton();
 		severityTop.setIcon(Data.getInstance().getIcon("pushTop_25x25_0.png"));
 		severityTop.setRolloverIcon(Data.getInstance().getIcon("pushTop_25x25.png"));
-		severityTop.setToolTipText(_("Push to the top"));
+		severityTop.setToolTipText(translate("Push to the top"));
 		severityTop.addActionListener(ActionRegistry.getInstance().get(PushSeverityTopAction.class.getName()));
 		buttonPanel.add(severityTop);
 
 		severityUp = GUITools.newImageButton();
 		severityUp.setIcon(Data.getInstance().getIcon("upArrow_25x25_0.png"));
 		severityUp.setRolloverIcon(Data.getInstance().getIcon("upArrow_25x25.png"));
-		severityUp.setToolTipText(_("Push up"));
+		severityUp.setToolTipText(translate("Push up"));
 		severityUp.addActionListener(ActionRegistry.getInstance().get(PushSeverityUpAction.class.getName()));
 		buttonPanel.add(severityUp);
 
 		severityDown = GUITools.newImageButton();
 		severityDown.setIcon(Data.getInstance().getIcon("downArrow_25x25_0.png"));
 		severityDown.setRolloverIcon(Data.getInstance().getIcon("downArrow_25x25.png"));
-		severityDown.setToolTipText(_("Push down"));
+		severityDown.setToolTipText(translate("Push down"));
 		severityDown.addActionListener(ActionRegistry.getInstance().get(PushSeverityDownAction.class.getName()));
 		buttonPanel.add(severityDown);
 
 		severityBottom = GUITools.newImageButton();
 		severityBottom.setIcon(Data.getInstance().getIcon("pushBottom_25x25_0.png"));
 		severityBottom.setRolloverIcon(Data.getInstance().getIcon("pushBottom_25x25.png"));
-		severityBottom.setToolTipText(_("Push to the bottom"));
+		severityBottom.setToolTipText(translate("Push to the bottom"));
 		severityBottom.addActionListener(ActionRegistry.getInstance().get(PushSeverityBottomAction.class.getName()));
 		buttonPanel.add(severityBottom);
 
@@ -231,8 +231,8 @@ public class ManageSeveritiesDialog extends AbstractDialog {
 	public ManageSeveritiesDialog(Frame parent) {
 		super(parent);
 
-		setTitle(_("Manage Severities"));
-		setDescription(_(
+		setTitle(translate("Manage Severities"));
+		setDescription(translate(
 				"The order of the severities for the findings affects the entire review and represents their relevance (decreasing from top to bottom in the list)."));
 		setIcon(Data.getInstance().getIcon("severities_50x50.png"));
 
@@ -245,7 +245,7 @@ public class ManageSeveritiesDialog extends AbstractDialog {
 		severityTbl.setShowGrid(false);
 		severityTbl.setShowHorizontalLines(true);
 
-		JButton close = new JButton(_("Close"), Data.getInstance().getIcon("buttonClose_16x16.png"));
+		JButton close = new JButton(translate("Close"), Data.getInstance().getIcon("buttonClose_16x16.png"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/src/org/revager/gui/dialogs/MeetingDialog.java
+++ b/src/org/revager/gui/dialogs/MeetingDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Container;
 import java.awt.Cursor;
@@ -240,8 +240,8 @@ public class MeetingDialog extends AbstractDialog {
 		locationTxtFld.setBorder(UI.STANDARD_BORDER_INLINE);
 
 		if (currentMeeting == null) {
-			setTitle(_("Add Meeting"));
-			setDescription(_("Here you can enter all information for the new review meeting."));
+			setTitle(translate("Add Meeting"));
+			setDescription(translate("Here you can enter all information for the new review meeting."));
 			setIcon(Data.getInstance().getIcon("addMeeting_50x50.png"));
 			setHelpChapter("meetings_management", "1");
 
@@ -261,10 +261,10 @@ public class MeetingDialog extends AbstractDialog {
 			locationTxtFld.setText("");
 			canceled.setEnabled(false);
 			canceled.setSelected(false);
-			canceledTxtArea.setText(_("Please enter the reason for canceling the meeting..."));
+			canceledTxtArea.setText(translate("Please enter the reason for canceling the meeting..."));
 		} else {
-			setTitle(_("Edit Meeting"));
-			setDescription(_("Here you can edit all information of the selected meeting."));
+			setTitle(translate("Edit Meeting"));
+			setDescription(translate("Here you can edit all information of the selected meeting."));
 			setIcon(Data.getInstance().getIcon("editMeeting_50x50.png"));
 			setHelpChapter("meetings_management", "2");
 			canceled.setEnabled(true);
@@ -322,8 +322,8 @@ public class MeetingDialog extends AbstractDialog {
 	public MeetingDialog(Frame parent) {
 		super(parent);
 
-		setTitle(_("Edit Meeting"));
-		setDescription(_("Here you can edit all information of the selected meeting."));
+		setTitle(translate("Edit Meeting"));
+		setDescription(translate("Here you can edit all information of the selected meeting."));
 		setIcon(Data.getInstance().getIcon("editMeeting_64x64.png"));
 
 		GridBagLayout gbl = new GridBagLayout();
@@ -340,10 +340,10 @@ public class MeetingDialog extends AbstractDialog {
 		GUITools.formatSpinner(beginHSpinner, hideBorder);
 		GUITools.formatSpinner(beginMSpinner, hideBorder);
 
-		JLabel beginLbl = new JLabel(_("Period of time:"));
+		JLabel beginLbl = new JLabel(translate("Period of time:"));
 
 		JPanel spinnerPanel = new JPanel(gbl);
-		JLabel tillLabel = new JLabel(_("to"));
+		JLabel tillLabel = new JLabel(translate("to"));
 
 		GUITools.addComponent(spinnerPanel, gbl, beginHSpinner, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, GridBagConstraints.NONE,
 				GridBagConstraints.NORTHWEST);
@@ -364,14 +364,14 @@ public class MeetingDialog extends AbstractDialog {
 		 * 
 		 * creating elements for location, and canceled infos
 		 */
-		JLabel locationLbl = new JLabel(_("Location:"));
+		JLabel locationLbl = new JLabel(translate("Location:"));
 		locationTxtFld = new JTextField();
 
-		canceledTxtArea = new JTextArea(_("Please enter the reason for canceling the meeting..."));
+		canceledTxtArea = new JTextArea(translate("Please enter the reason for canceling the meeting..."));
 		canceledTxtArea.setEnabled(false);
 
 		JScrollPane canceledScrllPn = GUITools.setIntoScrllPn(canceledTxtArea);
-		canceled = new JCheckBox(_("Canceled"));
+		canceled = new JCheckBox(translate("Canceled"));
 		canceled.setHorizontalTextPosition(SwingConstants.LEFT);
 		canceled.setMargin(new Insets(0, 0, 0, 0));
 		canceled.setBorder(new EmptyBorder(0, 0, 0, 0));
@@ -392,7 +392,7 @@ public class MeetingDialog extends AbstractDialog {
 		 * 
 		 * creating elements for the date of the meeting
 		 */
-		JLabel dateLbl = new JLabel(_("Date:"));
+		JLabel dateLbl = new JLabel(translate("Date:"));
 		dateTxtFld = new ObservingTextField();
 		dateTxtFld.setFocusable(false);
 		dateTxtFld.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
@@ -420,7 +420,7 @@ public class MeetingDialog extends AbstractDialog {
 		});
 
 		JButton datePicker = GUITools.newImageButton();
-		datePicker.setToolTipText(_("Select date"));
+		datePicker.setToolTipText(translate("Select date"));
 		datePicker.setIcon(Data.getInstance().getIcon("datePicker_25x25_0.png"));
 		datePicker.setRolloverIcon(Data.getInstance().getIcon("datePicker_25x25.png"));
 		datePicker.addActionListener(ActionRegistry.getInstance().get(DatePickerAction.class.getName()));
@@ -451,7 +451,7 @@ public class MeetingDialog extends AbstractDialog {
 		/*
 		 * buttons for accepting and canceling
 		 */
-		JButton cancel = new JButton(_("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
+		JButton cancel = new JButton(translate("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -461,7 +461,7 @@ public class MeetingDialog extends AbstractDialog {
 
 		addButton(cancel);
 
-		JButton confirm = new JButton(_("Confirm"), Data.getInstance().getIcon("buttonOk_16x16.png"));
+		JButton confirm = new JButton(translate("Confirm"), Data.getInstance().getIcon("buttonOk_16x16.png"));
 		confirm.addActionListener(ActionRegistry.getInstance().get(ConfirmMeetingAction.class.getName()));
 		addButton(confirm);
 

--- a/src/org/revager/gui/dialogs/SettingsDialog.java
+++ b/src/org/revager/gui/dialogs/SettingsDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -114,7 +114,7 @@ public class SettingsDialog extends AbstractDialog {
 	public SettingsDialog(Frame parent) {
 		super(parent);
 
-		setTitle(_("Application Settings"));
+		setTitle(translate("Application Settings"));
 		setIcon(Data.getInstance().getIcon("settingsDialog_64x64.png"));
 		setHelpChapter("options");
 
@@ -133,10 +133,10 @@ public class SettingsDialog extends AbstractDialog {
 		});
 
 		panelGeneral.setOpaque(true);
-		tabbedPane.addTab(_("General"), Data.getInstance().getIcon("tabGeneral_24x24.png"), panelGeneral);
+		tabbedPane.addTab(translate("General"), Data.getInstance().getIcon("tabGeneral_24x24.png"), panelGeneral);
 
 		panelPDF.setOpaque(true);
-		tabbedPane.addTab(_("PDF Export"), Data.getInstance().getIcon("tabPDF_24x24.png"), panelPDF);
+		tabbedPane.addTab(translate("PDF Export"), Data.getInstance().getIcon("tabPDF_24x24.png"), panelPDF);
 
 		getContentPane().setLayout(new BorderLayout());
 
@@ -145,7 +145,7 @@ public class SettingsDialog extends AbstractDialog {
 		/*
 		 * buttons
 		 */
-		JButton buttonConfirm = new JButton(_("Confirm"), Data.getInstance().getIcon("buttonOk_16x16.png"));
+		JButton buttonConfirm = new JButton(translate("Confirm"), Data.getInstance().getIcon("buttonOk_16x16.png"));
 		buttonConfirm.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -153,7 +153,7 @@ public class SettingsDialog extends AbstractDialog {
 			}
 		});
 
-		JButton buttonCancel = new JButton(_("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
+		JButton buttonCancel = new JButton(translate("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
 		buttonCancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -192,7 +192,7 @@ public class SettingsDialog extends AbstractDialog {
 		/*
 		 * Auto save
 		 */
-		String autoSaveText = _("Save review every {0} minutes automatically.");
+		String autoSaveText = translate("Save review every {0} minutes automatically.");
 		String[] textParts = autoSaveText.split("\\{0\\}");
 
 		String textPart1 = "";
@@ -229,7 +229,7 @@ public class SettingsDialog extends AbstractDialog {
 		 * Check updates
 		 */
 		checkboxCheckUpdates = new JCheckBox(
-				_("Check if a new version of RevAger is available during application start."));
+				translate("Check if a new version of RevAger is available during application start."));
 		checkboxCheckUpdates.setFocusPainted(false);
 
 		GridBagLayout gblCheckUpdates = new GridBagLayout();
@@ -241,7 +241,7 @@ public class SettingsDialog extends AbstractDialog {
 		/*
 		 * Show hints by default
 		 */
-		checkboxShowHints = new JCheckBox(_("Show hints in dialogs by default."));
+		checkboxShowHints = new JCheckBox(translate("Show hints in dialogs by default."));
 		checkboxShowHints.setFocusPainted(false);
 
 		GridBagLayout gblShowHints = new GridBagLayout();
@@ -253,7 +253,7 @@ public class SettingsDialog extends AbstractDialog {
 		/*
 		 * Highlight fields
 		 */
-		checkboxHighlightFields = new JCheckBox(_("Highlight obligatory input fields."));
+		checkboxHighlightFields = new JCheckBox(translate("Highlight obligatory input fields."));
 		checkboxHighlightFields.setFocusPainted(false);
 
 		GridBagLayout gblHighlightFields = new GridBagLayout();
@@ -265,7 +265,7 @@ public class SettingsDialog extends AbstractDialog {
 		/*
 		 * Allow usage of fullscreen mode
 		 */
-		checkboxFullscreen = new JCheckBox(_("Allow usage of fullscreen mode (EXPERIMENTAL)."));
+		checkboxFullscreen = new JCheckBox(translate("Allow usage of fullscreen mode (EXPERIMENTAL)."));
 		checkboxFullscreen.setFocusPainted(false);
 
 		GridBagLayout gblFullscreen = new GridBagLayout();
@@ -277,7 +277,7 @@ public class SettingsDialog extends AbstractDialog {
 		/*
 		 * Protocol warning
 		 */
-		String warnText = _("Show warning while creating a findings list after {0} minutes.");
+		String warnText = translate("Show warning while creating a findings list after {0} minutes.");
 		String[] warnParts = warnText.split("\\{0\\}");
 
 		String warnPart1 = "";
@@ -337,8 +337,8 @@ public class SettingsDialog extends AbstractDialog {
 				if (!currentLang.equals(selectedLang) && !langChangeHintAlreadyDisplayed) {
 					int option = JOptionPane.showConfirmDialog(UI.getInstance().getSettingsDialog(),
 							GUITools.getMessagePane(
-									_("You have to restart the application in order finalize the change of language. Restart now?")),
-							_("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+									translate("You have to restart the application in order finalize the change of language. Restart now?")),
+							translate("Question"), JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
 
 					langChangeHintAlreadyDisplayed = true;
 
@@ -358,7 +358,7 @@ public class SettingsDialog extends AbstractDialog {
 		GridBagLayout gblLanguage = new GridBagLayout();
 		JPanel panelLanguage = new JPanel(gblLanguage);
 
-		GUITools.addComponent(panelLanguage, gblLanguage, new JLabel(_("Language:")), 0, 0, 1, 1, 0.0, 0.0, 5, 42, 5, 5,
+		GUITools.addComponent(panelLanguage, gblLanguage, new JLabel(translate("Language:")), 0, 0, 1, 1, 0.0, 0.0, 5, 42, 5, 5,
 				GridBagConstraints.NONE, GridBagConstraints.WEST);
 		GUITools.addComponent(panelLanguage, gblLanguage, boxLanguage, 1, 0, 1, 1, 0.0, 0.0, 5, 5, 5, 5,
 				GridBagConstraints.NONE, GridBagConstraints.WEST);
@@ -392,7 +392,7 @@ public class SettingsDialog extends AbstractDialog {
 		 */
 		GridBagLayout gblPdfProtocol = new GridBagLayout();
 		JPanel panelPdfProtocol = new JPanel(gblPdfProtocol);
-		panelPdfProtocol.setBorder(BorderFactory.createTitledBorder(_("Findings list as PDF file")));
+		panelPdfProtocol.setBorder(BorderFactory.createTitledBorder(translate("Findings list as PDF file")));
 
 		labelImageProtocol = new JLabel();
 		labelImageProtocol.setOpaque(true);
@@ -401,7 +401,7 @@ public class SettingsDialog extends AbstractDialog {
 
 		JButton buttonBrowseProt = GUITools.newImageButton(Data.getInstance().getIcon("buttonBrowse_22x22_0.png"),
 				Data.getInstance().getIcon("buttonBrowse_22x22.png"));
-		buttonBrowseProt.setToolTipText(_("Choose an Image..."));
+		buttonBrowseProt.setToolTipText(translate("Choose an Image..."));
 		buttonBrowseProt.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -416,7 +416,7 @@ public class SettingsDialog extends AbstractDialog {
 
 		JButton buttonClearProt = GUITools.newImageButton(Data.getInstance().getIcon("clear_22x22_0.png"),
 				Data.getInstance().getIcon("clear_22x22.png"));
-		buttonClearProt.setToolTipText(_("Remove Image"));
+		buttonClearProt.setToolTipText(translate("Remove Image"));
 		buttonClearProt.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -426,7 +426,7 @@ public class SettingsDialog extends AbstractDialog {
 			}
 		});
 
-		GUITools.addComponent(panelPdfProtocol, gblPdfProtocol, new JLabel(_("Displayed image:")), 0, 0, 1, 1, 0.0, 1.0,
+		GUITools.addComponent(panelPdfProtocol, gblPdfProtocol, new JLabel(translate("Displayed image:")), 0, 0, 1, 1, 0.0, 1.0,
 				5, 5, 5, 5, GridBagConstraints.NONE, GridBagConstraints.WEST);
 		GUITools.addComponent(panelPdfProtocol, gblPdfProtocol, buttonClearProt, 1, 0, 1, 1, 0.0, 1.0, 5, 5, 5, 5,
 				GridBagConstraints.NONE, GridBagConstraints.WEST);
@@ -437,7 +437,7 @@ public class SettingsDialog extends AbstractDialog {
 
 		textFootProtocol = new JTextField();
 
-		GUITools.addComponent(panelPdfProtocol, gblPdfProtocol, new JLabel(_("Displayed foot text:")), 0, 1, 4, 1, 0.0,
+		GUITools.addComponent(panelPdfProtocol, gblPdfProtocol, new JLabel(translate("Displayed foot text:")), 0, 1, 4, 1, 0.0,
 				0.0, 5, 5, 0, 5, GridBagConstraints.NONE, GridBagConstraints.WEST);
 		GUITools.addComponent(panelPdfProtocol, gblPdfProtocol, textFootProtocol, 0, 2, 4, 1, 1.0, 0.0, 5, 5, 5, 5,
 				GridBagConstraints.HORIZONTAL, GridBagConstraints.WEST);
@@ -447,7 +447,7 @@ public class SettingsDialog extends AbstractDialog {
 		 */
 		GridBagLayout gblPdfInvitation = new GridBagLayout();
 		JPanel panelPdfInvitation = new JPanel(gblPdfInvitation);
-		panelPdfInvitation.setBorder(BorderFactory.createTitledBorder(_("Invitations as PDF file:")));
+		panelPdfInvitation.setBorder(BorderFactory.createTitledBorder(translate("Invitations as PDF file:")));
 
 		labelImageInvitation = new JLabel();
 		labelImageInvitation.setOpaque(true);
@@ -456,7 +456,7 @@ public class SettingsDialog extends AbstractDialog {
 
 		JButton buttonBrowseInv = GUITools.newImageButton(Data.getInstance().getIcon("buttonBrowse_22x22_0.png"),
 				Data.getInstance().getIcon("buttonBrowse_22x22.png"));
-		buttonBrowseInv.setToolTipText(_("Choose an Image..."));
+		buttonBrowseInv.setToolTipText(translate("Choose an Image..."));
 		buttonBrowseInv.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -471,7 +471,7 @@ public class SettingsDialog extends AbstractDialog {
 
 		JButton buttonClearInv = GUITools.newImageButton(Data.getInstance().getIcon("clear_22x22_0.png"),
 				Data.getInstance().getIcon("clear_22x22.png"));
-		buttonClearInv.setToolTipText(_("Remove Image"));
+		buttonClearInv.setToolTipText(translate("Remove Image"));
 		buttonClearInv.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -481,7 +481,7 @@ public class SettingsDialog extends AbstractDialog {
 			}
 		});
 
-		GUITools.addComponent(panelPdfInvitation, gblPdfInvitation, new JLabel(_("Displayed image:")), 0, 0, 1, 1, 0.0,
+		GUITools.addComponent(panelPdfInvitation, gblPdfInvitation, new JLabel(translate("Displayed image:")), 0, 0, 1, 1, 0.0,
 				1.0, 5, 5, 5, 5, GridBagConstraints.NONE, GridBagConstraints.WEST);
 		GUITools.addComponent(panelPdfInvitation, gblPdfInvitation, buttonClearInv, 1, 0, 1, 1, 0.0, 1.0, 5, 5, 5, 5,
 				GridBagConstraints.NONE, GridBagConstraints.WEST);
@@ -495,14 +495,14 @@ public class SettingsDialog extends AbstractDialog {
 		textInvitation.setWrapStyleWord(true);
 		textInvitation.setRows(3);
 
-		GUITools.addComponent(panelPdfInvitation, gblPdfInvitation, new JLabel(_("Text of invitations:")), 0, 1, 4, 1,
+		GUITools.addComponent(panelPdfInvitation, gblPdfInvitation, new JLabel(translate("Text of invitations:")), 0, 1, 4, 1,
 				0.0, 0.0, 5, 5, 0, 5, GridBagConstraints.NONE, GridBagConstraints.WEST);
 		GUITools.addComponent(panelPdfInvitation, gblPdfInvitation, GUITools.setIntoScrllPn(textInvitation), 0, 2, 4, 1,
 				1.0, 0.0, 5, 5, 5, 5, GridBagConstraints.HORIZONTAL, GridBagConstraints.WEST);
 
 		textFootInvitation = new JTextField();
 
-		GUITools.addComponent(panelPdfInvitation, gblPdfInvitation, new JLabel(_("Displayed foot text:")), 0, 3, 4, 1,
+		GUITools.addComponent(panelPdfInvitation, gblPdfInvitation, new JLabel(translate("Displayed foot text:")), 0, 3, 4, 1,
 				0.0, 0.0, 5, 5, 0, 5, GridBagConstraints.NONE, GridBagConstraints.WEST);
 		GUITools.addComponent(panelPdfInvitation, gblPdfInvitation, textFootInvitation, 0, 4, 4, 1, 1.0, 0.0, 5, 5, 5,
 				5, GridBagConstraints.HORIZONTAL, GridBagConstraints.WEST);
@@ -538,10 +538,10 @@ public class SettingsDialog extends AbstractDialog {
 		 * Dialog description
 		 */
 		if (tabbedPane.getSelectedComponent() == panelGeneral) {
-			setDescription(_(
+			setDescription(translate(
 					"Here you can set some application options. They will be saved in the database independently of any particular review."));
 		} else if (tabbedPane.getSelectedComponent() == panelPDF) {
-			setDescription(_(
+			setDescription(translate(
 					"Here you can set some options concerning the PDF export. They will be saved in the database independently of any particular review."));
 		} else {
 			setDescription("");
@@ -601,7 +601,7 @@ public class SettingsDialog extends AbstractDialog {
 			String language = ((Language) boxLanguage.getSelectedItem()).getLangCode();
 			appData.setSetting(AppSettingKey.APP_LANGUAGE, language);
 		} catch (DataException e) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 
@@ -649,7 +649,7 @@ public class SettingsDialog extends AbstractDialog {
 			appData.setSetting(AppSettingKey.PDF_INVITATION_FOOT_TEXT, textFootInvitation.getText());
 			appData.setSetting(AppSettingKey.PDF_INVITATION_TEXT, textInvitation.getText());
 		} catch (Exception e) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 	}
@@ -720,7 +720,7 @@ public class SettingsDialog extends AbstractDialog {
 				}
 			}
 		} catch (DataException e) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 
@@ -763,7 +763,7 @@ public class SettingsDialog extends AbstractDialog {
 				textInvitation.setText("");
 			}
 		} catch (DataException e) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 	}

--- a/src/org/revager/gui/dialogs/WarningDialog.java
+++ b/src/org/revager/gui/dialogs/WarningDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -38,7 +38,7 @@ import org.revager.tools.GUITools;
 @SuppressWarnings("serial")
 public class WarningDialog extends JDialog {
 
-	private String dontShowAgainString = _("Don't show this dialog during the current session again.");
+	private String dontShowAgainString = translate("Don't show this dialog during the current session again.");
 
 	private JCheckBox dontShowAgainBx = new JCheckBox(dontShowAgainString);
 
@@ -97,13 +97,13 @@ public class WarningDialog extends JDialog {
 		super(parent);
 		setLayout(gbl);
 		setModal(true);
-		setTitle(_("Attention!"));
+		setTitle(translate("Attention!"));
 
 		JLabel messageLabel = GUITools.getMessagePane(message);
 
-		JButton canceleBttn = new JButton(_("No"));
+		JButton canceleBttn = new JButton(translate("No"));
 		canceleBttn.addActionListener(new WarningAction(this, ButtonClicked.NO));
-		JButton acceptBttn = new JButton(_("Yes"));
+		JButton acceptBttn = new JButton(translate("Yes"));
 		acceptBttn.addActionListener(new WarningAction(this, ButtonClicked.YES));
 
 		GUITools.addComponent(this, gbl, messageLabel, 0, 0, 2, 1, 1.0, 0, 20, 10, 0, 10, GridBagConstraints.BOTH,

--- a/src/org/revager/gui/dialogs/assistant/AssistantDialog.java
+++ b/src/org/revager/gui/dialogs/assistant/AssistantDialog.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs.assistant;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Container;
@@ -76,12 +76,12 @@ public class AssistantDialog extends AbstractDialog {
 	/*
 	 * Strings
 	 */
-	private String firstScreenDescStrng = _("Welcome to RevAger!");
+	private String firstScreenDescStrng = translate("Welcome to RevAger!");
 
-	private String openRevDescStrng = _(
+	private String openRevDescStrng = translate(
 			"You can select a mode and a review from the list of reviews. If your review isn't in the list, you can load it by choosing 'Select another review...'.");
 
-	private String addAttDescStrng = _(
+	private String addAttDescStrng = translate(
 			"Here you can manage some personal details. They will be used during the review.");
 
 	/*
@@ -91,7 +91,7 @@ public class AssistantDialog extends AbstractDialog {
 	private JButton backBttn = new JButton();
 	private JButton finishBttn = new JButton();
 	private ImageIcon confirmIcon = Data.getInstance().getIcon("buttonOk_16x16.png");
-	private String confirmString = _("Confirm");
+	private String confirmString = translate("Confirm");
 
 	/**
 	 * Returns the currentPanel.
@@ -163,7 +163,7 @@ public class AssistantDialog extends AbstractDialog {
 		getContentPane().setLayout(new BorderLayout());
 		backBttn.addActionListener(ActionRegistry.getInstance().get(GoToFirstScreenPnlAction.class.getName()));
 
-		setTitle(_("RevAger Assistant"));
+		setTitle(translate("RevAger Assistant"));
 
 		updateContents();
 
@@ -181,7 +181,7 @@ public class AssistantDialog extends AbstractDialog {
 	 */
 	private void defineWizardBttns() {
 
-		backBttn.setText(_("Back"));
+		backBttn.setText(translate("Back"));
 		backBttn.setIcon(Data.getInstance().getIcon("buttonBack_16x16.png"));
 
 		finishBttn.setText(confirmString);

--- a/src/org/revager/gui/dialogs/assistant/FirstScreenPanel.java
+++ b/src/org/revager/gui/dialogs/assistant/FirstScreenPanel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs.assistant;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -72,18 +72,18 @@ public class FirstScreenPanel extends AbstractDialogPanel {
 	 */
 	int max = 27;
 
-	private String openRevStrng = AppTools.cutString(_("Open existing review"), max);
-	private String languageStrng = AppTools.cutString(_("Select language"), max);
-	private String aspectsManagerStrng = AppTools.cutString(_("Open Aspects Manager"), max);
-	private String newReviewStrng = AppTools.cutString(_("Schedule new review"), max);
-	private String quickstartStrng = AppTools.cutString(_("Quickstart"), max);
+	private String openRevStrng = AppTools.cutString(translate("Open existing review"), max);
+	private String languageStrng = AppTools.cutString(translate("Select language"), max);
+	private String aspectsManagerStrng = AppTools.cutString(translate("Open Aspects Manager"), max);
+	private String newReviewStrng = AppTools.cutString(translate("Schedule new review"), max);
+	private String quickstartStrng = AppTools.cutString(translate("Quickstart"), max);
 
-	private String quickRevTooltipStrng = _(
+	private String quickRevTooltipStrng = translate(
 			"Select this if you would like to start a review immediately as a single reviewer. This option is perfect for quick reviews of a website or even for car inspections.");
-	private String newRevTooltipStrng = _("Select this if you would like to organize a review as moderator.");
-	private String openRevTooltipStrng = _("Select this if you would like to open an existing review.");
-	private String selectLanguageTooltipStrng = _("Select this if you want to change the language of the application.");
-	private String openAspectsMngrTooltipStrng = _(
+	private String newRevTooltipStrng = translate("Select this if you would like to organize a review as moderator.");
+	private String openRevTooltipStrng = translate("Select this if you would like to open an existing review.");
+	private String selectLanguageTooltipStrng = translate("Select this if you want to change the language of the application.");
+	private String openAspectsMngrTooltipStrng = translate(
 			"Select this if you would like to manage the catalogs and aspects in the Aspects Manager.");
 
 	/*

--- a/src/org/revager/gui/dialogs/assistant/LanguagePopupWindow.java
+++ b/src/org/revager/gui/dialogs/assistant/LanguagePopupWindow.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs.assistant;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -125,7 +125,7 @@ public class LanguagePopupWindow extends JDialog {
 
 		// setUndecorated(true);
 		setResizable(false);
-		setTitle(_("RevAger"));
+		setTitle(translate("RevAger"));
 
 		setModal(true);
 
@@ -162,13 +162,13 @@ public class LanguagePopupWindow extends JDialog {
 		JButton buttonAbort = GUITools.newImageButton();
 		buttonAbort.setIcon(Data.getInstance().getIcon("buttonCancel_24x24_0.png"));
 		buttonAbort.setRolloverIcon(Data.getInstance().getIcon("buttonCancel_24x24.png"));
-		buttonAbort.setToolTipText(_("Abort"));
+		buttonAbort.setToolTipText(translate("Abort"));
 		buttonAbort.addActionListener(new LanguagePopupWindowAction(this, ButtonClicked.ABORT));
 
 		JButton buttonConfirm = GUITools.newImageButton();
 		buttonConfirm.setIcon(Data.getInstance().getIcon("buttonOk_24x24_0.png"));
 		buttonConfirm.setRolloverIcon(Data.getInstance().getIcon("buttonOk_24x24.png"));
-		buttonConfirm.setToolTipText(_("Confirm"));
+		buttonConfirm.setToolTipText(translate("Confirm"));
 		buttonConfirm.addActionListener(new LanguagePopupWindowAction(this, ButtonClicked.OK));
 
 		JPanel panelButtons = new JPanel(new BorderLayout());

--- a/src/org/revager/gui/dialogs/assistant/OpenReviewPanel.java
+++ b/src/org/revager/gui/dialogs/assistant/OpenReviewPanel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.dialogs.assistant;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Font;
 import java.awt.GridBagConstraints;
@@ -59,8 +59,8 @@ public class OpenReviewPanel extends AbstractDialogPanel {
 	/*
 	 * Strings
 	 */
-	private String anotherRevStrng = _("Select another review...");
-	private String noRevsStrng = _("No reviews available");
+	private String anotherRevStrng = translate("Select another review...");
+	private String noRevsStrng = translate("No reviews available");
 	private String firstRevStrng;
 	private String secondRevStrng;
 	private String thirdRevStrng;
@@ -238,7 +238,7 @@ public class OpenReviewPanel extends AbstractDialogPanel {
 				vecLastReviews.add(new File(rev).getName());
 			}
 		} catch (DataException exc) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 

--- a/src/org/revager/gui/findings_list/AddAspToFindPopupWindow.java
+++ b/src/org/revager/gui/findings_list/AddAspToFindPopupWindow.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.findings_list;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -107,14 +107,14 @@ public class AddAspToFindPopupWindow extends JDialog {
 
 		// setUndecorated(true);
 		setResizable(false);
-		setTitle(_("RevAger"));
+		setTitle(translate("RevAger"));
 
 		setModal(true);
 
 		JPanel panelBase = GUITools.newPopupBasePanel();
 
 		JTextArea textTitle = GUITools
-				.newPopupTitleArea(_("Please select the aspects which should be added to the finding:"));
+				.newPopupTitleArea(translate("Please select the aspects which should be added to the finding:"));
 
 		panelBase.add(textTitle, BorderLayout.NORTH);
 
@@ -127,7 +127,7 @@ public class AddAspToFindPopupWindow extends JDialog {
 		resiAspList = aspectMgmt.getAspects();
 		selAspList = new ArrayList<Aspect>();
 
-		JLabel aspFilLbl = new JLabel(_("Filter:"));
+		JLabel aspFilLbl = new JLabel(translate("Filter:"));
 		filterTxtFld = new JTextField();
 
 		filterTxtFld.addKeyListener(new KeyListener() {
@@ -174,13 +174,13 @@ public class AddAspToFindPopupWindow extends JDialog {
 		JButton buttonAbort = GUITools.newImageButton();
 		buttonAbort.setIcon(Data.getInstance().getIcon("buttonCancel_24x24_0.png"));
 		buttonAbort.setRolloverIcon(Data.getInstance().getIcon("buttonCancel_24x24.png"));
-		buttonAbort.setToolTipText(_("Abort"));
+		buttonAbort.setToolTipText(translate("Abort"));
 		buttonAbort.addActionListener(new AddAspToFindPopupWindowAction(this, ButtonClicked.ABORT));
 
 		JButton buttonConfirm = GUITools.newImageButton();
 		buttonConfirm.setIcon(Data.getInstance().getIcon("buttonOk_24x24_0.png"));
 		buttonConfirm.setRolloverIcon(Data.getInstance().getIcon("buttonOk_24x24.png"));
-		buttonConfirm.setToolTipText(_("Confirm"));
+		buttonConfirm.setToolTipText(translate("Confirm"));
 		buttonConfirm.addActionListener(new AddAspToFindPopupWindowAction(this, ButtonClicked.OK));
 
 		JPanel panelButtons = new JPanel(new BorderLayout());

--- a/src/org/revager/gui/findings_list/AddAttToFLPopupWindow.java
+++ b/src/org/revager/gui/findings_list/AddAttToFLPopupWindow.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.findings_list;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -168,7 +168,7 @@ public class AddAttToFLPopupWindow extends JDialog {
 
 		// setUndecorated(true);
 		setResizable(false);
-		setTitle(_("RevAger"));
+		setTitle(translate("RevAger"));
 
 		setModal(true);
 
@@ -178,10 +178,10 @@ public class AddAttToFLPopupWindow extends JDialog {
 
 		panelBase.add(textTitle, BorderLayout.NORTH);
 
-		JLabel durLbl = new JLabel(_("Preparation time:"));
-		JLabel roleLbl = new JLabel(_("Role:"));
-		JLabel contactLbl = new JLabel(_("Contact information:"));
-		JLabel nameLbl = new JLabel(_("Name:"));
+		JLabel durLbl = new JLabel(translate("Preparation time:"));
+		JLabel roleLbl = new JLabel(translate("Role:"));
+		JLabel contactLbl = new JLabel(translate("Contact information:"));
+		JLabel nameLbl = new JLabel(translate("Name:"));
 
 		contactTxtArea = new JTextArea();
 		nameTxtFld = new JTextField();
@@ -208,8 +208,8 @@ public class AddAttToFLPopupWindow extends JDialog {
 		JPanel spinnerPanel = new JPanel(gbl);
 		spinnerPanel.setBackground(null);
 
-		JLabel hoursLbl = new JLabel(_("Hour(s)"));
-		JLabel minLbl = new JLabel(_("Minute(s)"));
+		JLabel hoursLbl = new JLabel(translate("Hour(s)"));
+		JLabel minLbl = new JLabel(translate("Minute(s)"));
 
 		GUITools.addComponent(spinnerPanel, gbl, durHSpinner, 1, 0, 1, 1, 0.0, 0.0, 5, 0, 0, 0,
 				GridBagConstraints.HORIZONTAL, GridBagConstraints.WEST);
@@ -223,7 +223,7 @@ public class AddAttToFLPopupWindow extends JDialog {
 		roleBx = new JComboBox();
 		for (Role x : Role.values()) {
 			String roleString = x.toString();
-			roleBx.addItem(_(roleString));
+			roleBx.addItem(translate(roleString));
 		}
 
 		scrllPn = GUITools.setIntoScrllPn(contactTxtArea);
@@ -261,7 +261,7 @@ public class AddAttToFLPopupWindow extends JDialog {
 			selAtt = Application.getInstance().getProtocolMgmt().getAttendees(prot).get(selRow);
 
 			nameTxtFld.setText(selAtt.getName());
-			roleBx.setSelectedItem(_(selAtt.getRole().toString()));
+			roleBx.setSelectedItem(translate(selAtt.getRole().toString()));
 			contactTxtArea.setText(selAtt.getContact());
 			durHSpinner
 					.setValue(Application.getInstance().getProtocolMgmt().getAttendeePrepTime(selAtt, prot).getHours());
@@ -276,13 +276,13 @@ public class AddAttToFLPopupWindow extends JDialog {
 		JButton buttonAbort = GUITools.newImageButton();
 		buttonAbort.setIcon(Data.getInstance().getIcon("buttonCancel_24x24_0.png"));
 		buttonAbort.setRolloverIcon(Data.getInstance().getIcon("buttonCancel_24x24.png"));
-		buttonAbort.setToolTipText(_("Abort"));
+		buttonAbort.setToolTipText(translate("Abort"));
 		buttonAbort.addActionListener(new AddAttToProtPopupWindowAction(this, ButtonClicked.ABORT));
 
 		buttonConfirm = GUITools.newImageButton();
 		buttonConfirm.setIcon(Data.getInstance().getIcon("buttonOk_24x24_0.png"));
 		buttonConfirm.setRolloverIcon(Data.getInstance().getIcon("buttonOk_24x24.png"));
-		buttonConfirm.setToolTipText(_("Confirm"));
+		buttonConfirm.setToolTipText(translate("Confirm"));
 		buttonConfirm.addActionListener(new AddAttToProtPopupWindowAction(this, ButtonClicked.OK));
 
 		JPanel panelButtons = new JPanel(new BorderLayout());

--- a/src/org/revager/gui/findings_list/AddResiAttToFLPopupWindow.java
+++ b/src/org/revager/gui/findings_list/AddResiAttToFLPopupWindow.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.findings_list;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -119,21 +119,21 @@ public class AddResiAttToFLPopupWindow extends JDialog {
 
 		// setUndecorated(true);
 		setResizable(false);
-		setTitle(_("RevAger"));
+		setTitle(translate("RevAger"));
 
 		setModal(true);
 
 		JPanel panelBase = GUITools.newPopupBasePanel();
 
 		JTextArea textTitle = GUITools
-				.newPopupTitleArea(_("Please select the attendee you would like to add to the current meeting:"));
+				.newPopupTitleArea(translate("Please select the attendee you would like to add to the current meeting:"));
 
 		attendeeBx = new JComboBox();
 		createAttendeeBx();
 
 		panelBase.add(textTitle, BorderLayout.NORTH);
 
-		JLabel durLbl = new JLabel(_("Preparation time:"));
+		JLabel durLbl = new JLabel(translate("Preparation time:"));
 
 		durHSpinner = new JSpinner(new SpinnerNumberModel(0, 0, 99, 1));
 		durMSpinner = new JSpinner(new SpinnerNumberModel(0, 0, 59, 1));
@@ -157,8 +157,8 @@ public class AddResiAttToFLPopupWindow extends JDialog {
 		JPanel spinnerPanel = new JPanel(gbl);
 		spinnerPanel.setBackground(null);
 
-		JLabel hoursLbl = new JLabel(_("Hour(s)"));
-		JLabel minLbl = new JLabel(_("Minute(s)"));
+		JLabel hoursLbl = new JLabel(translate("Hour(s)"));
+		JLabel minLbl = new JLabel(translate("Minute(s)"));
 
 		GUITools.addComponent(spinnerPanel, gbl, durHSpinner, 1, 0, 1, 1, 0.0, 0, 5, 0, 0, 0,
 				GridBagConstraints.HORIZONTAL, GridBagConstraints.WEST);
@@ -190,13 +190,13 @@ public class AddResiAttToFLPopupWindow extends JDialog {
 		JButton buttonAbort = GUITools.newImageButton();
 		buttonAbort.setIcon(Data.getInstance().getIcon("buttonCancel_24x24_0.png"));
 		buttonAbort.setRolloverIcon(Data.getInstance().getIcon("buttonCancel_24x24.png"));
-		buttonAbort.setToolTipText(_("Abort"));
+		buttonAbort.setToolTipText(translate("Abort"));
 		buttonAbort.addActionListener(new AddResiAttToProtPopupWindowAction(this, ButtonClicked.ABORT));
 
 		JButton buttonConfirm = GUITools.newImageButton();
 		buttonConfirm.setIcon(Data.getInstance().getIcon("buttonOk_24x24_0.png"));
 		buttonConfirm.setRolloverIcon(Data.getInstance().getIcon("buttonOk_24x24.png"));
-		buttonConfirm.setToolTipText(_("Confirm"));
+		buttonConfirm.setToolTipText(translate("Confirm"));
 		buttonConfirm.addActionListener(new AddResiAttToProtPopupWindowAction(this, ButtonClicked.OK));
 
 		JPanel panelButtons = new JPanel(new BorderLayout());
@@ -233,7 +233,7 @@ public class AddResiAttToFLPopupWindow extends JDialog {
 	private void createAttendeeBx() {
 		for (Attendee att : Application.getInstance().getAttendeeMgmt().getAttendees()) {
 			if (!Application.getInstance().getProtocolMgmt().isAttendee(att, protocol)) {
-				String role = _(att.getRole().toString());
+				String role = translate(att.getRole().toString());
 
 				attendeeBx.addItem(att.getName() + " (" + role + ")");
 

--- a/src/org/revager/gui/findings_list/FindingPanel.java
+++ b/src/org/revager/gui/findings_list/FindingPanel.java
@@ -1,6 +1,6 @@
 package org.revager.gui.findings_list;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -256,12 +256,12 @@ public class FindingPanel extends JPanel {
 		/*
 		 * Set tooltips for buttons
 		 */
-		buttonCloseFinding.setToolTipText(_("Close Edit View of this Finding"));
-		buttonRemoveFinding.setToolTipText(_("Remove this Finding"));
-		buttonPushUp.setToolTipText(_("Push up Finding"));
-		buttonPushDown.setToolTipText(_("Push down Finding"));
-		buttonPushTop.setToolTipText(_("Push Finding to the top"));
-		buttonPushBottom.setToolTipText(_("Push Finding to the bottom"));
+		buttonCloseFinding.setToolTipText(translate("Close Edit View of this Finding"));
+		buttonRemoveFinding.setToolTipText(translate("Remove this Finding"));
+		buttonPushUp.setToolTipText(translate("Push up Finding"));
+		buttonPushDown.setToolTipText(translate("Push down Finding"));
+		buttonPushTop.setToolTipText(translate("Push Finding to the top"));
+		buttonPushBottom.setToolTipText(translate("Push Finding to the bottom"));
 
 		/*
 		 * Buttons for references table
@@ -276,7 +276,7 @@ public class FindingPanel extends JPanel {
 					tableReferences.getCellEditor().stopCellEditing();
 				}
 
-				String ref = _("Please enter a reference");
+				String ref = translate("Please enter a reference");
 				findMgmt.addReference(ref, finding);
 				modelReferences.fireTableDataChanged();
 
@@ -320,9 +320,9 @@ public class FindingPanel extends JPanel {
 			}
 		});
 
-		buttonAddReference.setToolTipText(_("Add Reference"));
-		buttonRemoveReference.setToolTipText(_("Remove Reference"));
-		buttonEditReference.setToolTipText(_("Edit Reference"));
+		buttonAddReference.setToolTipText(translate("Add Reference"));
+		buttonRemoveReference.setToolTipText(translate("Remove Reference"));
+		buttonEditReference.setToolTipText(translate("Edit Reference"));
 
 		buttonRemoveReference.setEnabled(false);
 		buttonEditReference.setEnabled(false);
@@ -369,9 +369,9 @@ public class FindingPanel extends JPanel {
 			}
 		});
 
-		buttonAddExtReference.setToolTipText(_("Add File"));
-		buttonRemoveExtReference.setToolTipText(_("Remove file"));
-		buttonPasteExtReference.setToolTipText(_("Paste Image from Clipboard"));
+		buttonAddExtReference.setToolTipText(translate("Add File"));
+		buttonRemoveExtReference.setToolTipText(translate("Remove file"));
+		buttonPasteExtReference.setToolTipText(translate("Paste Image from Clipboard"));
 
 		buttonRemoveExtReference.setEnabled(false);
 
@@ -422,8 +422,8 @@ public class FindingPanel extends JPanel {
 			}
 		});
 
-		buttonAddAspect.setToolTipText(_("Add Aspect(s)"));
-		buttonRemoveAspect.setToolTipText(_("Remove Aspect(s)"));
+		buttonAddAspect.setToolTipText(translate("Add Aspect(s)"));
+		buttonRemoveAspect.setToolTipText(translate("Remove Aspect(s)"));
 
 		buttonRemoveAspect.setEnabled(false);
 
@@ -473,7 +473,7 @@ public class FindingPanel extends JPanel {
 								Desktop.getDesktop().open(ref);
 							} catch (Exception exc) {
 								JOptionPane.showMessageDialog(UI.getInstance().getProtocolFrame(),
-										GUITools.getMessagePane(exc.getMessage()), _("Error"),
+										GUITools.getMessagePane(exc.getMessage()), translate("Error"),
 										JOptionPane.ERROR_MESSAGE);
 							}
 						}
@@ -523,7 +523,7 @@ public class FindingPanel extends JPanel {
 		labelFindingSeverity.setForeground(Color.DARK_GRAY);
 
 		labelFindingTitle.setFont(UI.PROTOCOL_FONT_BOLD);
-		labelFindingTitle.setText(_("Finding") + " " + finding.getId());
+		labelFindingTitle.setText(translate("Finding") + " " + finding.getId());
 
 		scrollDescription = GUITools.setIntoScrllPn(textDescription);
 		GUITools.scrollToTop(scrollDescription);
@@ -580,8 +580,8 @@ public class FindingPanel extends JPanel {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				if (JOptionPane.showConfirmDialog(UI.getInstance().getProtocolFrame(),
-						GUITools.getMessagePane(_("Are you sure you want to remove the selected finding permanently?")),
-						_("Question"), JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
+						GUITools.getMessagePane(translate("Are you sure you want to remove the selected finding permanently?")),
+						translate("Question"), JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
 					findingsTab.removeCurrentFinding();
 				}
 			}
@@ -732,8 +732,8 @@ public class FindingPanel extends JPanel {
 
 		this.setPreferredSize(COMPACT_VIEW_SIZE);
 
-		this.setToolTipText(finding.getAspects().size() + " " + _("Aspect(s)") + ", " + finding.getReferences().size()
-				+ " " + _("Reference(s)") + ", " + finding.getExternalReferences().size() + " " + _("File(s)"));
+		this.setToolTipText(finding.getAspects().size() + " " + translate("Aspect(s)") + ", " + finding.getReferences().size()
+				+ " " + translate("Reference(s)") + ", " + finding.getExternalReferences().size() + " " + translate("File(s)"));
 
 		this.removeAll();
 
@@ -754,7 +754,7 @@ public class FindingPanel extends JPanel {
 		/*
 		 * Update labels
 		 */
-		labelFindingNumber.setText(_("Finding") + " " + finding.getId());
+		labelFindingNumber.setText(translate("Finding") + " " + finding.getId());
 
 		labelFindingSeverity.setText(findMgmt.getLocalizedSeverity(finding));
 
@@ -966,7 +966,7 @@ public class FindingPanel extends JPanel {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					UI.getInstance().getProtocolFrame().switchToProgressMode(_("Getting image from clipboard ..."));
+					UI.getInstance().getProtocolFrame().switchToProgressMode(translate("Getting image from clipboard ..."));
 				}
 			});
 
@@ -975,8 +975,8 @@ public class FindingPanel extends JPanel {
 			if (img == null) {
 				JOptionPane.showMessageDialog(UI.getInstance().getProtocolFrame(),
 						GUITools.getMessagePane(
-								_("Unfortunately there isn't any image in the clipboard which can be included as a reference.")),
-						_("Information"), JOptionPane.INFORMATION_MESSAGE);
+								translate("Unfortunately there isn't any image in the clipboard which can be included as a reference.")),
+						translate("Information"), JOptionPane.INFORMATION_MESSAGE);
 			} else {
 				Image scalImg = img.getScaledInstance(-1, 250, Image.SCALE_SMOOTH);
 
@@ -985,17 +985,17 @@ public class FindingPanel extends JPanel {
 						new MatteBorder(1, 1, 1, 1, UI.SEPARATOR_COLOR)));
 
 				JTextField inputField = new JTextField();
-				inputField.setText(_("Screenshot"));
+				inputField.setText(translate("Screenshot"));
 
 				JPanel messagePane = new JPanel(new BorderLayout());
 				messagePane.add(labelImg, BorderLayout.NORTH);
-				messagePane.add(new JLabel(_("Please enter a name for the image:")), BorderLayout.CENTER);
+				messagePane.add(new JLabel(translate("Please enter a name for the image:")), BorderLayout.CENTER);
 				messagePane.add(inputField, BorderLayout.SOUTH);
 
-				Object[] options = { _("Save"), _("Edit"), _("Cancel") };
+				Object[] options = { translate("Save"), translate("Edit"), translate("Cancel") };
 
 				int action = JOptionPane.showOptionDialog(UI.getInstance().getProtocolFrame(), messagePane,
-						_("Confirm"), JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, options,
+						translate("Confirm"), JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.PLAIN_MESSAGE, null, options,
 						options[0]);
 
 				String fileName = null;

--- a/src/org/revager/gui/findings_list/FindingsListFrame.java
+++ b/src/org/revager/gui/findings_list/FindingsListFrame.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.findings_list;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -332,8 +332,8 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 					exc.printStackTrace();
 
 					JOptionPane.showMessageDialog(UI.getInstance().getProtocolFrame(),
-							GUITools.getMessagePane(_("Severe problem occurred! RevAger has to be restarted.")),
-							_("Problem occurred"), JOptionPane.ERROR_MESSAGE);
+							GUITools.getMessagePane(translate("Severe problem occurred! RevAger has to be restarted.")),
+							translate("Problem occurred"), JOptionPane.ERROR_MESSAGE);
 
 					ExitAction exitAction = ((ExitAction) ActionRegistry.getInstance().get(ExitAction.class.getName()));
 
@@ -354,10 +354,10 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 
 				tabbedPane.setTabPlacement(SwingConstants.TOP);
 
-				tabbedPane.add(_("Organizational"), tabPanelOrg);
-				tabbedPane.add(_("Impression"), tabGenImp);
-				tabbedPane.add(_("Findings"), tabPanelFindings);
-				tabbedPane.add(_("Comments & Recommendation"), tabPanelCommAndRec);
+				tabbedPane.add(translate("Organizational"), tabPanelOrg);
+				tabbedPane.add(translate("Impression"), tabGenImp);
+				tabbedPane.add(translate("Findings"), tabPanelFindings);
+				tabbedPane.add(translate("Comments & Recommendation"), tabPanelCommAndRec);
 
 				tabbedPane.addChangeListener(tabChangeListener);
 
@@ -377,7 +377,7 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 
 		tbConfirmProt = GUITools.newImageButton(Data.getInstance().getIcon("confirmProtocol_50x50_0.png"),
 				Data.getInstance().getIcon("confirmProtocol_50x50.png"));
-		tbConfirmProt.setToolTipText(_("Confirm and close list of findings"));
+		tbConfirmProt.setToolTipText(translate("Confirm and close list of findings"));
 		tbConfirmProt.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -400,7 +400,7 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 
 		tbPdfExport = GUITools.newImageButton(Data.getInstance().getIcon("PDFExport_50x50_0.png"),
 				Data.getInstance().getIcon("PDFExport_50x50.png"));
-		tbPdfExport.setToolTipText(_("Export List of Findings as PDF File"));
+		tbPdfExport.setToolTipText(translate("Export List of Findings as PDF File"));
 		tbPdfExport.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -414,7 +414,7 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 
 		tbCsvExport = GUITools.newImageButton(Data.getInstance().getIcon("CSVExport_50x50_0.png"),
 				Data.getInstance().getIcon("CSVExport_50x50.png"));
-		tbCsvExport.setToolTipText(_("Export List of Findings as CSV File"));
+		tbCsvExport.setToolTipText(translate("Export List of Findings as CSV File"));
 		tbCsvExport.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -431,11 +431,11 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 		if (fullscreen) {
 			tbFullscreen.setIcon(Data.getInstance().getIcon("fullscreenClose_50x50_0.png"));
 			tbFullscreen.setRolloverIcon(Data.getInstance().getIcon("fullscreenClose_50x50.png"));
-			tbFullscreen.setToolTipText(_("Exit Fullscreen"));
+			tbFullscreen.setToolTipText(translate("Exit Fullscreen"));
 		} else {
 			tbFullscreen.setIcon(Data.getInstance().getIcon("fullscreen_50x50_0.png"));
 			tbFullscreen.setRolloverIcon(Data.getInstance().getIcon("fullscreen_50x50.png"));
-			tbFullscreen.setToolTipText(_("Change to Fullscreen mode"));
+			tbFullscreen.setToolTipText(translate("Change to Fullscreen mode"));
 		}
 		tbFullscreen.addActionListener(new ActionListener() {
 			@Override
@@ -479,7 +479,7 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 
 		clockButtonReset = GUITools.newImageButton(Data.getInstance().getIcon("clockReset_24x24_0.png"),
 				Data.getInstance().getIcon("clockReset_24x24.png"));
-		clockButtonReset.setToolTipText(_("Reset Stop Watch"));
+		clockButtonReset.setToolTipText(translate("Reset Stop Watch"));
 		clockButtonReset.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -508,11 +508,11 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 		if (clockWorker.isClockRunning()) {
 			clockButtonStart.setIcon(Data.getInstance().getIcon("clockPause_24x24_0.png"));
 			clockButtonStart.setRolloverIcon(Data.getInstance().getIcon("clockPause_24x24.png"));
-			clockButtonStart.setToolTipText(_("Pause Stop Watch"));
+			clockButtonStart.setToolTipText(translate("Pause Stop Watch"));
 		} else {
 			clockButtonStart.setIcon(Data.getInstance().getIcon("clockStart_24x24_0.png"));
 			clockButtonStart.setRolloverIcon(Data.getInstance().getIcon("clockStart_24x24.png"));
-			clockButtonStart.setToolTipText(_("Start Stop Watch"));
+			clockButtonStart.setToolTipText(translate("Start Stop Watch"));
 		}
 	}
 
@@ -528,28 +528,28 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 		addResiAtt = GUITools.newImageButton();
 		addResiAtt.setIcon(Data.getInstance().getIcon("addResiAtt_25x25_0.png"));
 		addResiAtt.setRolloverIcon(Data.getInstance().getIcon("addResiAtt_25x25.png"));
-		addResiAtt.setToolTipText(_("Add Attendee from the Attendee Pool"));
+		addResiAtt.setToolTipText(translate("Add Attendee from the Attendee Pool"));
 		addResiAtt.addActionListener(ActionRegistry.getInstance().get(AddResiAttToProtAction.class.getName()));
 		attendeeButtons.add(addResiAtt);
 
 		addAttendee = GUITools.newImageButton();
 		addAttendee.setIcon(Data.getInstance().getIcon("addAttendee_25x25_0.png"));
 		addAttendee.setRolloverIcon(Data.getInstance().getIcon("addAttendee_25x25.png"));
-		addAttendee.setToolTipText(_("Add Attendee"));
+		addAttendee.setToolTipText(translate("Add Attendee"));
 		addAttendee.addActionListener(ActionRegistry.getInstance().get(AddAttToProtAction.class.getName()));
 		attendeeButtons.add(addAttendee);
 
 		removeAttendee = GUITools.newImageButton();
 		removeAttendee.setIcon(Data.getInstance().getIcon("removeAttendee_25x25_0.png"));
 		removeAttendee.setRolloverIcon(Data.getInstance().getIcon("removeAttendee_25x25.png"));
-		removeAttendee.setToolTipText(_("Remove Attendee"));
+		removeAttendee.setToolTipText(translate("Remove Attendee"));
 		removeAttendee.addActionListener(ActionRegistry.getInstance().get(RemAttFromProtAction.class.getName()));
 		attendeeButtons.add(removeAttendee);
 
 		editAttendee = GUITools.newImageButton();
 		editAttendee.setIcon(Data.getInstance().getIcon("editAttendee_25x25_0.png"));
 		editAttendee.setRolloverIcon(Data.getInstance().getIcon("editAttendee_25x25.png"));
-		editAttendee.setToolTipText(_("Edit Attendee"));
+		editAttendee.setToolTipText(translate("Edit Attendee"));
 		editAttendee.addActionListener(ActionRegistry.getInstance().get(EditAttFromProtAction.class.getName()));
 		attendeeButtons.add(editAttendee);
 
@@ -673,7 +673,7 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 
 		scrllP = GUITools.setIntoScrollPane(presentAttTable);
 		scrllP.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-		scrllP.setToolTipText(_("Add Attendee to Meeting"));
+		scrllP.setToolTipText(translate("Add Attendee to Meeting"));
 		scrllP.addMouseListener(new MouseListener() {
 			@Override
 			public void mouseClicked(MouseEvent e) {
@@ -701,7 +701,7 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 			}
 		});
 
-		JLabel labelAttendees = new JLabel(_("Attendees of the current meeting:"));
+		JLabel labelAttendees = new JLabel(translate("Attendees of the current meeting:"));
 		labelAttendees.setFont(UI.PROTOCOL_TITLE_FONT);
 
 		GUITools.addComponent(attPanel, gbl, labelAttendees, 0, 0, 2, 1, 1.0, 0.0, 20, 20, 0, 20,
@@ -713,7 +713,7 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 	}
 
 	private void createImpPanel() {
-		JLabel impLbl = new JLabel(_("General impression of the product:"));
+		JLabel impLbl = new JLabel(translate("General impression of the product:"));
 		impLbl.setFont(UI.PROTOCOL_FONT_BOLD);
 
 		impTxtArea = new JTextArea();
@@ -740,16 +740,16 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 	 * Creates the bottom org panel.
 	 */
 	private void createBottomOrgPanel() {
-		JLabel locationLbl = new JLabel(_("Location:"));
+		JLabel locationLbl = new JLabel(translate("Location:"));
 		locationLbl.setFont(UI.PROTOCOL_FONT_BOLD);
 
-		JLabel dateLbl = new JLabel(_("Date:"));
+		JLabel dateLbl = new JLabel(translate("Date:"));
 		dateLbl.setFont(UI.PROTOCOL_FONT_BOLD);
 
-		JLabel beginLbl = new JLabel(_("Period of time:"));
+		JLabel beginLbl = new JLabel(translate("Period of time:"));
 		beginLbl.setFont(UI.PROTOCOL_FONT_BOLD);
 
-		JLabel tillLabel = new JLabel(_("to"));
+		JLabel tillLabel = new JLabel(translate("to"));
 		tillLabel.setFont(UI.PROTOCOL_FONT_BOLD);
 
 		clockLabel.setFont(UI.PROTOCOL_FONT_BOLD);
@@ -908,13 +908,13 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 	 */
 	private void createCommAndRatePanel() {
 
-		JLabel recLbl = new JLabel(_("Final recommendation for the product:"));
+		JLabel recLbl = new JLabel(translate("Final recommendation for the product:"));
 		recLbl.setFont(UI.PROTOCOL_FONT_BOLD);
 
-		JLabel meetCommLbl = new JLabel(_("Comments on the meeting:"));
+		JLabel meetCommLbl = new JLabel(translate("Comments on the meeting:"));
 		meetCommLbl.setFont(UI.PROTOCOL_FONT_BOLD);
 
-		JLabel protCommLbl = new JLabel(_("Comments on the list of findings:"));
+		JLabel protCommLbl = new JLabel(translate("Comments on the list of findings:"));
 		protCommLbl.setFont(UI.PROTOCOL_FONT_BOLD);
 
 		meetCommTxtArea = new JTextArea();
@@ -1018,11 +1018,11 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 
 			if (seconds > warningTime * 60 && showWarning && !clockWorker.isWarningDisplayed()) {
 				String message = MessageFormat.format(
-						_("This review meeting is running for {0} minutes already. Therefore it is recommended to finalize the meeting now and continue the review at a later point in time."),
+						translate("This review meeting is running for {0} minutes already. Therefore it is recommended to finalize the meeting now and continue the review at a later point in time."),
 						Integer.toString(warningTime));
 
 				JOptionPane.showMessageDialog(UI.getInstance().getProtocolFrame(), GUITools.getMessagePane(message),
-						_("Information"), JOptionPane.INFORMATION_MESSAGE);
+						translate("Information"), JOptionPane.INFORMATION_MESSAGE);
 
 				clockWorker.setWarningDisplayed(true);
 			}
@@ -1063,8 +1063,8 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 
 		UI.getInstance().getProtocolClockWorker().addObserverFrame(this);
 
-		setTitle(_("List of Findings"));
-		setStatusMessage(_("List of findings successfully loaded."), false);
+		setTitle(translate("List of Findings"));
+		setStatusMessage(translate("List of findings successfully loaded."), false);
 
 		getContentPane().setLayout(new BorderLayout());
 		setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
@@ -1432,24 +1432,24 @@ public class FindingsListFrame extends AbstractFrame implements Observer {
 		setNumberOfHints(2);
 
 		hintAtt = new HintItem(
-				_("Please add at least one attendee to the meeting by choosing one from the attendees pool or create a new one (Tab 'Organizational')."),
+				translate("Please add at least one attendee to the meeting by choosing one from the attendees pool or create a new one (Tab 'Organizational')."),
 				HintItem.WARNING);
 
 		hintImpr = new HintItem(
-				_("Please enter the general impression for the product into the provided text field (Tab 'Impression')."),
+				translate("Please enter the general impression for the product into the provided text field (Tab 'Impression')."),
 				HintItem.WARNING);
 
 		hintRec = new HintItem(
-				_("Please enter the final recommendation for the product into the provided text field (Tab 'Comments & Recommendation')."),
+				translate("Please enter the final recommendation for the product into the provided text field (Tab 'Comments & Recommendation')."),
 				HintItem.WARNING);
 
-		hintFind = new HintItem(_("For every finding enter at least a description (Tab 'Findings')."),
+		hintFind = new HintItem(translate("For every finding enter at least a description (Tab 'Findings')."),
 				HintItem.WARNING);
 
-		hintOk = new HintItem(_("The meeting data and its list of findings is complete."), HintItem.OK);
+		hintOk = new HintItem(translate("The meeting data and its list of findings is complete."), HintItem.OK);
 
 		hintInfoNewFinding = new HintItem(
-				_("In order to add a new finding to the list of findings use the 'Add Finding' button (Tab 'Findings')."),
+				translate("In order to add a new finding to the list of findings use the 'Add Finding' button (Tab 'Findings')."),
 				HintItem.INFO);
 	}
 

--- a/src/org/revager/gui/findings_list/FindingsTab.java
+++ b/src/org/revager/gui/findings_list/FindingsTab.java
@@ -1,6 +1,6 @@
 package org.revager.gui.findings_list;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -46,7 +46,7 @@ public class FindingsTab extends JPanel {
 
 	private JPanel panelStrut = new JPanel();
 
-	private JButton buttonAddFinding = new JButton(_("Add Finding"));
+	private JButton buttonAddFinding = new JButton(translate("Add Finding"));
 	private JLabel labelNumOfFindings = new JLabel();
 
 	private Map<Finding, Integer> gridBagPositions = new HashMap<Finding, Integer>();
@@ -121,7 +121,7 @@ public class FindingsTab extends JPanel {
 			currentFindingPanel.storeFindingData();
 		}
 
-		labelNumOfFindings.setText(findMgmt.getNumberOfFindings(protocol) + " " + _("Findings"));
+		labelNumOfFindings.setText(findMgmt.getNumberOfFindings(protocol) + " " + translate("Findings"));
 
 		/*
 		 * Update the tooltip

--- a/src/org/revager/gui/findings_list/graphical_annotations/ImageEditorDialog.java
+++ b/src/org/revager/gui/findings_list/graphical_annotations/ImageEditorDialog.java
@@ -1,6 +1,6 @@
 package org.revager.gui.findings_list.graphical_annotations;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -120,7 +120,7 @@ public class ImageEditorDialog extends AbstractDialog {
 			}
 		});
 
-		setTitle(_("Image Editor"));
+		setTitle(translate("Image Editor"));
 
 		ImageAnnotation annotation = ImageAnnotation.newEllipseAnnotation(currentColor, DEFAULT_THICKNESS);
 
@@ -205,7 +205,7 @@ public class ImageEditorDialog extends AbstractDialog {
 				updateUndoRedoButtons();
 			}
 		});
-		buttonUndo.setToolTipText(_("Undo"));
+		buttonUndo.setToolTipText(translate("Undo"));
 
 		buttonRedo = GUITools.newImageButton(Data.getInstance().getIcon("redo_50x50_0.png"),
 				Data.getInstance().getIcon("redo_50x50.png"));
@@ -216,7 +216,7 @@ public class ImageEditorDialog extends AbstractDialog {
 				updateUndoRedoButtons();
 			}
 		});
-		buttonRedo.setToolTipText(_("Redo"));
+		buttonRedo.setToolTipText(translate("Redo"));
 
 		buttonGroup = new ButtonGroup();
 
@@ -272,7 +272,7 @@ public class ImageEditorDialog extends AbstractDialog {
 		buttonText.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				TextPopupWindow popup = new TextPopupWindow(getImageEditorDialog(), _("Please enter some text"),
+				TextPopupWindow popup = new TextPopupWindow(getImageEditorDialog(), translate("Please enter some text"),
 						currentText, false);
 
 				popup.setVisible(true);
@@ -327,7 +327,7 @@ public class ImageEditorDialog extends AbstractDialog {
 		registerInToolTipManager(panelThickness);
 
 		buttonColor = new JPanel();
-		buttonColor.setToolTipText(_("Color"));
+		buttonColor.setToolTipText(translate("Color"));
 		buttonColor.setPreferredSize(new Dimension(32, 32));
 		buttonColor.setBackground(currentColor);
 		buttonColor.setBorder(new MatteBorder(2, 2, 2, 2, Color.GRAY));
@@ -335,7 +335,7 @@ public class ImageEditorDialog extends AbstractDialog {
 		buttonColor.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent e) {
-				Color selectedColor = JColorChooser.showDialog(getImageEditorDialog(), _("Please choose a color"),
+				Color selectedColor = JColorChooser.showDialog(getImageEditorDialog(), translate("Please choose a color"),
 						currentColor);
 
 				if (selectedColor != null) {
@@ -382,7 +382,7 @@ public class ImageEditorDialog extends AbstractDialog {
 		panelTop.add(panelTopRight, BorderLayout.EAST);
 		setTopPanel(panelTop);
 
-		buttonCancel = new JButton(_("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
+		buttonCancel = new JButton(translate("Abort"), Data.getInstance().getIcon("buttonCancel_16x16.png"));
 		buttonCancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent ev) {
@@ -396,7 +396,7 @@ public class ImageEditorDialog extends AbstractDialog {
 
 		addButton(buttonCancel);
 
-		buttonConfirm = new JButton(_("Confirm"), Data.getInstance().getIcon("buttonOk_16x16.png"));
+		buttonConfirm = new JButton(translate("Confirm"), Data.getInstance().getIcon("buttonOk_16x16.png"));
 		buttonConfirm.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -426,7 +426,7 @@ public class ImageEditorDialog extends AbstractDialog {
 				new Dimension((int) panelThicknessPreview.getSize().getWidth(), sliderThickness.getValue()));
 		panelThicknessPreview.revalidate();
 
-		String tooltip = _("Thickness") + ": " + Integer.toString(sliderThickness.getValue()) + " px";
+		String tooltip = translate("Thickness") + ": " + Integer.toString(sliderThickness.getValue()) + " px";
 
 		panelThickness.setToolTipText(tooltip);
 		sliderThickness.setToolTipText(tooltip);

--- a/src/org/revager/gui/helpers/DatePicker.java
+++ b/src/org/revager/gui/helpers/DatePicker.java
@@ -7,7 +7,7 @@
  */
 package org.revager.gui.helpers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -628,7 +628,7 @@ public class DatePicker extends Observable implements Runnable, WindowFocusListe
 
 		// screen.setUndecorated(true);
 		screen.setResizable(false);
-		screen.setTitle(_("RevAger"));
+		screen.setTitle(translate("RevAger"));
 
 		screen.getContentPane().setLayout(new BorderLayout());
 		screen.getContentPane().add(panelBase, BorderLayout.CENTER);
@@ -925,60 +925,60 @@ public class DatePicker extends Observable implements Runnable, WindowFocusListe
 	 */
 	public String getString(String key) {
 		if (key.equals("month.0")) {
-			return _("January");
+			return translate("January");
 		} else if (key.equals("month.1")) {
-			return _("February");
+			return translate("February");
 		} else if (key.equals("month.2")) {
-			return _("March");
+			return translate("March");
 		} else if (key.equals("month.3")) {
-			return _("April");
+			return translate("April");
 		} else if (key.equals("month.4")) {
-			return _("May");
+			return translate("May");
 		} else if (key.equals("month.5")) {
-			return _("June");
+			return translate("June");
 		} else if (key.equals("month.6")) {
-			return _("July");
+			return translate("July");
 		} else if (key.equals("month.7")) {
-			return _("August");
+			return translate("August");
 		} else if (key.equals("month.8")) {
-			return _("September");
+			return translate("September");
 		} else if (key.equals("month.9")) {
-			return _("October");
+			return translate("October");
 		} else if (key.equals("month.10")) {
-			return _("November");
+			return translate("November");
 		} else if (key.equals("month.11")) {
-			return _("December");
+			return translate("December");
 		} else if (key.equals("week.0")) {
-			return _("Mon");
+			return translate("Mon");
 		} else if (key.equals("week.1")) {
-			return _("Tue");
+			return translate("Tue");
 		} else if (key.equals("week.2")) {
-			return _("Wed");
+			return translate("Wed");
 		} else if (key.equals("week.3")) {
-			return _("Thu");
+			return translate("Thu");
 		} else if (key.equals("week.4")) {
-			return _("Fri");
+			return translate("Fri");
 		} else if (key.equals("week.5")) {
-			return _("Sat");
+			return translate("Sat");
 		} else if (key.equals("week.6")) {
-			return _("Sun");
+			return translate("Sun");
 		} else if (key.equals("prevMonth")) {
-			return _("Previous month");
+			return translate("Previous month");
 		} else if (key.equals("nextMonth")) {
-			return _("Next month");
+			return translate("Next month");
 		} else if (key.equals("prevYear")) {
-			return _("Previous year");
+			return translate("Previous year");
 		} else if (key.equals("nextYear")) {
-			return _("Next year");
+			return translate("Next year");
 		} else if (key.equals("close")) {
-			return _("Close");
+			return translate("Close");
 		} else if (key.equals("hint")) {
-			return _("Please choose a date...");
+			return translate("Please choose a date...");
 		} else if (key.equals("tooltip")) {
-			return _("Calendar");
+			return translate("Calendar");
 		}
 
-		return _(key);
+		return translate(key);
 	}
 
 	/**

--- a/src/org/revager/gui/helpers/FileChooser.java
+++ b/src/org/revager/gui/helpers/FileChooser.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.helpers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Dialog;
 import java.awt.FileDialog;
@@ -168,7 +168,7 @@ public class FileChooser {
 
 			switch (chooserMode) {
 			case MODE_OPEN_FILE:
-				dialog.setTitle(_("Open File..."));
+				dialog.setTitle(translate("Open File..."));
 
 				dialog.setDirectory(this.dir.getAbsolutePath());
 				if (this.file != null) {
@@ -187,7 +187,7 @@ public class FileChooser {
 				break;
 
 			case MODE_SAVE_FILE:
-				dialog.setTitle(_("Save File..."));
+				dialog.setTitle(translate("Save File..."));
 
 				dialog.setDirectory(this.dir.getAbsolutePath());
 				if (this.file != null) {
@@ -206,7 +206,7 @@ public class FileChooser {
 				break;
 
 			case MODE_SELECT_DIRECTORY:
-				dialog.setTitle(_("Select Directory..."));
+				dialog.setTitle(translate("Select Directory..."));
 
 				dialog.setFilenameFilter(new ResiFileFilter(ResiFileFilter.TYPE_DIRECTORY));
 
@@ -240,10 +240,10 @@ public class FileChooser {
 					 */
 					if (getDialogType() == OPEN_DIALOG) {
 						if (!f.exists()) {
-							String errMsg = _("Cannot find the given file. Please select a valid one.");
+							String errMsg = translate("Cannot find the given file. Please select a valid one.");
 
 							JOptionPane.showMessageDialog(getTopLevelAncestor(), GUITools.getMessagePane(errMsg),
-									_("Error"), JOptionPane.ERROR_MESSAGE);
+									translate("Error"), JOptionPane.ERROR_MESSAGE);
 
 							return;
 						}
@@ -257,12 +257,12 @@ public class FileChooser {
 						 * Show warning if file exists
 						 */
 						if (f.exists()) {
-							String questMsg = _(
+							String questMsg = translate(
 									"There is a file with the given name already existing. Would you like to overwrite it?")
 									+ "\n\n" + this.getSelectedFile().getAbsolutePath();
 
 							int result = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
-									GUITools.getMessagePane(questMsg), _("Question"), JOptionPane.YES_NO_OPTION,
+									GUITools.getMessagePane(questMsg), translate("Question"), JOptionPane.YES_NO_OPTION,
 									JOptionPane.QUESTION_MESSAGE);
 							switch (result) {
 							case JOptionPane.YES_OPTION:
@@ -293,7 +293,7 @@ public class FileChooser {
 
 			switch (chooserMode) {
 			case MODE_OPEN_FILE:
-				dialog.setDialogTitle(_("Open File..."));
+				dialog.setDialogTitle(translate("Open File..."));
 
 				dialog.setFileSelectionMode(JFileChooser.FILES_ONLY);
 
@@ -310,7 +310,7 @@ public class FileChooser {
 				break;
 
 			case MODE_SAVE_FILE:
-				dialog.setDialogTitle(_("Save File..."));
+				dialog.setDialogTitle(translate("Save File..."));
 
 				dialog.setFileSelectionMode(JFileChooser.FILES_ONLY);
 				dialog.setFileFilter(filter);
@@ -319,8 +319,8 @@ public class FileChooser {
 				break;
 
 			case MODE_SELECT_DIRECTORY:
-				dialog.setDialogTitle(_("Select Directory..."));
-				dialog.setApproveButtonText(_("Select"));
+				dialog.setDialogTitle(translate("Select Directory..."));
+				dialog.setApproveButtonText(translate("Select"));
 
 				dialog.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 				dialog.setFileFilter(new ResiFileFilter(ResiFileFilter.TYPE_DIRECTORY));
@@ -345,7 +345,7 @@ public class FileChooser {
 			} else if (selected == JFileChooser.ERROR_OPTION) {
 				JOptionPane.showMessageDialog(parent,
 						GUITools.getMessagePane(
-								_("An error occurred while choosing a file or directory!\n\nPlease try again.")),
+								translate("An error occurred while choosing a file or directory!\n\nPlease try again.")),
 						Data.getInstance().getResource("appName"), JOptionPane.ERROR_MESSAGE);
 
 				selected = SELECTED_ERROR;

--- a/src/org/revager/gui/helpers/TreeProtocol.java
+++ b/src/org/revager/gui/helpers/TreeProtocol.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.helpers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.text.DateFormat;
 
@@ -105,7 +105,7 @@ public class TreeProtocol {
 				location = " | " + location;
 			}
 
-			String protFrom = _("Findings List of");
+			String protFrom = translate("Findings List of");
 			String protocolName = protFrom + " " + date + " | " + start + " - " + end + " (" + timezone + ")"
 					+ location;
 

--- a/src/org/revager/gui/models/AspectTableModel.java
+++ b/src/org/revager/gui/models/AspectTableModel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.models;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -139,9 +139,9 @@ public class AspectTableModel extends AbstractTableModel {
 	@Override
 	public String getColumnName(int column) {
 		if (column == 0) {
-			return _("Aspect");
+			return translate("Aspect");
 		} else {
-			return _("Reviewers");
+			return translate("Reviewers");
 		}
 	}
 

--- a/src/org/revager/gui/models/AttendeeTableModel.java
+++ b/src/org/revager/gui/models/AttendeeTableModel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.models;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import javax.swing.JLabel;
 import javax.swing.table.AbstractTableModel;
@@ -64,11 +64,11 @@ public class AttendeeTableModel extends AbstractTableModel {
 	@Override
 	public String getColumnName(int column) {
 		if (column == 1)
-			return _("Name");
+			return translate("Name");
 		else if (column == 2)
-			return _("Role");
+			return translate("Role");
 		else if (column == 3)
-			return _("Aspects");
+			return translate("Aspects");
 		else
 			return null;
 	}
@@ -89,13 +89,13 @@ public class AttendeeTableModel extends AbstractTableModel {
 			String roleString = Application.getInstance().getAttendeeMgmt().getAttendees().get(rowIndex).getRole()
 					.toString();
 
-			return _(roleString);
+			return translate(roleString);
 		} else if (columnIndex == 3) {
 			try {
 				String value = String.valueOf(Application.getInstance().getAttendeeMgmt().getAttendees().get(rowIndex)
 						.getAspects().getAspectIds().size());
 
-				return value.concat(" ").concat(_("Aspect(s)"));
+				return value.concat(" ").concat(translate("Aspect(s)"));
 			} catch (Exception e) {
 				return "";
 			}

--- a/src/org/revager/gui/models/CSVColumnsComboBoxModel.java
+++ b/src/org/revager/gui/models/CSVColumnsComboBoxModel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.models;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -38,10 +38,10 @@ public class CSVColumnsComboBoxModel extends AbstractListModel implements ComboB
 
 	private Map<String, AppCSVColumnName> columns = new HashMap<String, AppCSVColumnName>();
 
-	private final String DESCRIPTION = _("Description");
-	private final String REFERENCE = _("Reference");
-	private final String SEVERITY = _("Severity");
-	private final String REPORTER = _("Bug Reporter");
+	private final String DESCRIPTION = translate("Description");
+	private final String REFERENCE = translate("Reference");
+	private final String SEVERITY = translate("Severity");
+	private final String REPORTER = translate("Bug Reporter");
 
 	private String selection = null;
 

--- a/src/org/revager/gui/models/CSVProfileTableModel.java
+++ b/src/org/revager/gui/models/CSVProfileTableModel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.models;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.util.List;
 
@@ -134,9 +134,9 @@ public class CSVProfileTableModel extends AbstractTableModel {
 	@Override
 	public String getColumnName(int column) {
 		if (column == 0)
-			return _("Review Severity");
+			return translate("Review Severity");
 		else
-			return _("Mapping");
+			return translate("Mapping");
 
 	}
 

--- a/src/org/revager/gui/models/FindAspTableModel.java
+++ b/src/org/revager/gui/models/FindAspTableModel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.models;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import javax.swing.table.AbstractTableModel;
 
@@ -81,7 +81,7 @@ public class FindAspTableModel extends AbstractTableModel {
 	 */
 	@Override
 	public String getColumnName(int column) {
-		return _("Aspect(s)");
+		return translate("Aspect(s)");
 	}
 
 }

--- a/src/org/revager/gui/models/FindExtRefTableModel.java
+++ b/src/org/revager/gui/models/FindExtRefTableModel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.models;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import javax.swing.table.AbstractTableModel;
 
@@ -82,6 +82,6 @@ public class FindExtRefTableModel extends AbstractTableModel {
 	 */
 	@Override
 	public String getColumnName(int column) {
-		return _("Files");
+		return translate("Files");
 	}
 }

--- a/src/org/revager/gui/models/FindRefTableModel.java
+++ b/src/org/revager/gui/models/FindRefTableModel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.models;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import javax.swing.table.AbstractTableModel;
 
@@ -104,7 +104,7 @@ public class FindRefTableModel extends AbstractTableModel {
 	 */
 	@Override
 	public String getColumnName(int column) {
-		return _("References");
+		return translate("References");
 	}
 
 }

--- a/src/org/revager/gui/models/PresentAttendeesTableModel.java
+++ b/src/org/revager/gui/models/PresentAttendeesTableModel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.models;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.util.List;
 
@@ -96,12 +96,12 @@ public class PresentAttendeesTableModel extends AbstractTableModel {
 			return "<html><b>" + name + "</b><br>" + contact + "</html>";
 		} else if (column == 2) {
 			String roleString = localAttList.get(row).getRole().toString();
-			return _(roleString);
+			return translate(roleString);
 		} else if (column == 3) {
 			int aspNumber = Application.getInstance().getAttendeeMgmt().getNumberOfAspects(localAttList.get(row));
 
 			if (aspNumber > 0) {
-				return aspNumber + " " + _("Aspects");
+				return aspNumber + " " + translate("Aspects");
 			} else {
 				return "";
 			}
@@ -111,7 +111,7 @@ public class PresentAttendeesTableModel extends AbstractTableModel {
 			String hours = String.format("%02d", localDur.getHours());
 			String mins = String.format("%02d", localDur.getMinutes());
 
-			return _("Preparation time") + ": " + hours + ":" + mins;
+			return translate("Preparation time") + ": " + hours + ":" + mins;
 		} else
 			return null;
 	}

--- a/src/org/revager/gui/models/ReviewerTableModel.java
+++ b/src/org/revager/gui/models/ReviewerTableModel.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.models;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.util.List;
 
@@ -93,9 +93,9 @@ public class ReviewerTableModel extends AbstractTableModel {
 	@Override
 	public String getColumnName(int column) {
 		if (column == 1) {
-			return _("Category");
+			return translate("Category");
 		} else {
-			return _("Aspect");
+			return translate("Aspect");
 		}
 	}
 

--- a/src/org/revager/gui/workers/AutoAspAllocWorker.java
+++ b/src/org/revager/gui/workers/AutoAspAllocWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -78,7 +78,7 @@ public class AutoAspAllocWorker extends SwingWorker<Void, Void> {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(_("Allocating aspects ..."));
+				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(translate("Allocating aspects ..."));
 			}
 		});
 
@@ -98,14 +98,14 @@ public class AutoAspAllocWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Aspects allocated."), false);
+					UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Aspects allocated."), false);
 				}
 			});
 		} else {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Cannot allocate aspects!"), false);
+					UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Cannot allocate aspects!"), false);
 				}
 			});
 		}

--- a/src/org/revager/gui/workers/AutoBackupWorker.java
+++ b/src/org/revager/gui/workers/AutoBackupWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -84,7 +84,7 @@ public class AutoBackupWorker extends SwingWorker<Void, Void> {
 						@Override
 						public void run() {
 							for (AbstractFrame af : obsFrames) {
-								af.setStatusMessage(_("Auto backup done."), false);
+								af.setStatusMessage(translate("Auto backup done."), false);
 							}
 						}
 					});
@@ -97,7 +97,7 @@ public class AutoBackupWorker extends SwingWorker<Void, Void> {
 					@Override
 					public void run() {
 						for (AbstractFrame af : obsFrames) {
-							af.setStatusMessage(_("Auto backup failed!"), false);
+							af.setStatusMessage(translate("Auto backup failed!"), false);
 						}
 					}
 				});

--- a/src/org/revager/gui/workers/AutoSaveWorker.java
+++ b/src/org/revager/gui/workers/AutoSaveWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -96,7 +96,7 @@ public class AutoSaveWorker extends SwingWorker<Void, Void> {
 						@Override
 						public void run() {
 							for (AbstractFrame af : obsFrames) {
-								af.setStatusMessage(_("Review stored successfully."), false);
+								af.setStatusMessage(translate("Review stored successfully."), false);
 							}
 						}
 					});
@@ -111,7 +111,7 @@ public class AutoSaveWorker extends SwingWorker<Void, Void> {
 					@Override
 					public void run() {
 						for (AbstractFrame af : obsFrames) {
-							af.setStatusMessage(_("Review couldn't be stored!"), false);
+							af.setStatusMessage(translate("Review couldn't be stored!"), false);
 						}
 					}
 				});

--- a/src/org/revager/gui/workers/CheckForNewVersionWorker.java
+++ b/src/org/revager/gui/workers/CheckForNewVersionWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Desktop;
 import java.net.URL;
@@ -64,14 +64,14 @@ public class CheckForNewVersionWorker extends SwingWorker<Void, Void> {
 				String remoteVersion = versionProp.getProperty("version", localVersion);
 
 				String newVersionAvail = MessageFormat.format(
-						_("A new version of RevAger is available!\n\nLatest version: {0}\nYour version: {1}\n\nPlease choose 'Update' to get the latest version. If you don't like to see this message again, you can turn it off in the application settings."),
+						translate("A new version of RevAger is available!\n\nLatest version: {0}\nYour version: {1}\n\nPlease choose 'Update' to get the latest version. If you don't like to see this message again, you can turn it off in the application settings."),
 						remoteVersion, localVersion);
 
 				if (remoteBuild > localBuild) {
-					Object[] options = { _("Update RevAger"), _("Ignore") };
+					Object[] options = { translate("Update RevAger"), translate("Ignore") };
 
 					if (JOptionPane.showOptionDialog(UI.getInstance().getMainFrame(),
-							GUITools.getMessagePane(newVersionAvail), _("Question"), JOptionPane.YES_NO_OPTION,
+							GUITools.getMessagePane(newVersionAvail), translate("Question"), JOptionPane.YES_NO_OPTION,
 							JOptionPane.QUESTION_MESSAGE, null, options, options[0]) == JOptionPane.YES_OPTION) {
 						Desktop.getDesktop()
 								.browse(new URL(Data.getInstance().getResource("currVerBrowseURL")).toURI());

--- a/src/org/revager/gui/workers/CreateInvitationsWorker.java
+++ b/src/org/revager/gui/workers/CreateInvitationsWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Desktop;
 import java.io.File;
@@ -62,7 +62,7 @@ public class CreateInvitationsWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					dialog.switchToProgressMode(_("Creating invitation(s) ..."));
+					dialog.switchToProgressMode(translate("Creating invitation(s) ..."));
 				}
 			});
 
@@ -95,7 +95,7 @@ public class CreateInvitationsWorker extends SwingWorker<Void, Void> {
 				});
 
 				JOptionPane.showMessageDialog(UI.getInstance().getExportCSVDialog(),
-						GUITools.getMessagePane(exc.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+						GUITools.getMessagePane(exc.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 			}
 
 			dialog.notifySwitchToEditMode();
@@ -107,7 +107,7 @@ public class CreateInvitationsWorker extends SwingWorker<Void, Void> {
 					dialog.switchToEditMode();
 
 					UI.getInstance().getMainFrame()
-							.setStatusMessage(_("The invitations have been created successfully."), false);
+							.setStatusMessage(translate("The invitations have been created successfully."), false);
 				}
 			});
 
@@ -119,14 +119,14 @@ public class CreateInvitationsWorker extends SwingWorker<Void, Void> {
 					if (dialog.getSelectedAttendees().isEmpty()) {
 						dialog.markAttScrollPane();
 						dialog.setMessage(
-								_("You have to choose at least one attendee in order to create an invitation."));
+								translate("You have to choose at least one attendee in order to create an invitation."));
 
 						return;
 					}
 
 					if (dialog.getSelectedPath().trim().equals("")) {
 						dialog.markPathTxtField();
-						dialog.setMessage(_("Please choose a directory where to store the invitation(s)."));
+						dialog.setMessage(translate("Please choose a directory where to store the invitation(s)."));
 
 						return;
 					}

--- a/src/org/revager/gui/workers/ExportAspectsWorker.java
+++ b/src/org/revager/gui/workers/ExportAspectsWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.util.List;
 
@@ -75,7 +75,7 @@ public class ExportAspectsWorker extends SwingWorker<Void, Void> {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(_("Exporting aspects ..."));
+				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(translate("Exporting aspects ..."));
 			}
 		});
 
@@ -97,18 +97,18 @@ public class ExportAspectsWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Aspects exported successfully."),
+					UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Aspects exported successfully."),
 							false);
 				}
 			});
 		} catch (Exception e) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Cannot export the selected aspects!"),
+					UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Cannot export the selected aspects!"),
 							false);
 				}
 			});

--- a/src/org/revager/gui/workers/ExportCSVWorker.java
+++ b/src/org/revager/gui/workers/ExportCSVWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Desktop;
 import java.io.File;
@@ -116,10 +116,10 @@ public class ExportCSVWorker extends SwingWorker<Void, Void> {
 					public void run() {
 						if (protFrame.isVisible()) {
 							protFrame.setStatusMessage(
-									_("The findings have been exported into a CSV file successfully."), false);
+									translate("The findings have been exported into a CSV file successfully."), false);
 						} else {
 							mainFrame.setStatusMessage(
-									_("The findings have been exported into a CSV file successfully."), false);
+									translate("The findings have been exported into a CSV file successfully."), false);
 						}
 					}
 				});
@@ -136,7 +136,7 @@ public class ExportCSVWorker extends SwingWorker<Void, Void> {
 				});
 
 				JOptionPane.showMessageDialog(UI.getInstance().getExportCSVDialog(),
-						GUITools.getMessagePane(e.getMessage()), _("Error"), JOptionPane.ERROR_MESSAGE);
+						GUITools.getMessagePane(e.getMessage()), translate("Error"), JOptionPane.ERROR_MESSAGE);
 			}
 
 		}

--- a/src/org/revager/gui/workers/ExportCatalogWorker.java
+++ b/src/org/revager/gui/workers/ExportCatalogWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
@@ -75,7 +75,7 @@ public class ExportCatalogWorker extends SwingWorker<Void, Void> {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(_("Exporting catalog ..."));
+				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(translate("Exporting catalog ..."));
 			}
 		});
 
@@ -107,18 +107,18 @@ public class ExportCatalogWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Catalog exported successfully."),
+					UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Catalog exported successfully."),
 							false);
 				}
 			});
 		} catch (Exception e) {
-			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), _("Error"),
+			JOptionPane.showMessageDialog(null, GUITools.getMessagePane(e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Cannot export selected catalog!"),
+					UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Cannot export selected catalog!"),
 							false);
 				}
 			});

--- a/src/org/revager/gui/workers/ExportPDFProtocolWorker.java
+++ b/src/org/revager/gui/workers/ExportPDFProtocolWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.Desktop;
 import java.io.File;
@@ -69,7 +69,7 @@ public class ExportPDFProtocolWorker extends SwingWorker<Void, Void> {
 		String fileName = null;
 
 		if (UI.getInstance().getExportPDFProtocolDialog().exportRev()) {
-			fileName = sdf.format(new Date()) + "_" + _("Review_Findings_List");
+			fileName = sdf.format(new Date()) + "_" + translate("Review_Findings_List");
 		} else {
 			int year = meet.getProtocol().getDate().get(Calendar.YEAR);
 			int month = meet.getProtocol().getDate().get(Calendar.MONTH) + 1;
@@ -86,7 +86,7 @@ public class ExportPDFProtocolWorker extends SwingWorker<Void, Void> {
 				dayStr = "0" + dayStr;
 			}
 
-			fileName = year + "-" + monthStr + "-" + dayStr + "_" + _("Review_Meeting_Findings_List");
+			fileName = year + "-" + monthStr + "-" + dayStr + "_" + translate("Review_Meeting_Findings_List");
 		}
 
 		fileChooser.setFile(new File(fileName));
@@ -130,10 +130,10 @@ public class ExportPDFProtocolWorker extends SwingWorker<Void, Void> {
 					public void run() {
 						if (protFrame.isVisible()) {
 							protFrame.setStatusMessage(
-									_("The findings list has been exported as a PDF file successfully."), false);
+									translate("The findings list has been exported as a PDF file successfully."), false);
 						} else {
 							mainFrame.setStatusMessage(
-									_("The findings list has been exported as a PDF file successfully."), false);
+									translate("The findings list has been exported as a PDF file successfully."), false);
 						}
 					}
 				});
@@ -143,8 +143,8 @@ public class ExportPDFProtocolWorker extends SwingWorker<Void, Void> {
 				} catch (IOException e) {
 					JOptionPane.showMessageDialog(null,
 							GUITools.getMessagePane(
-									_("RevAger cannot find a PDF viewer on your machine. Please install a PDF Viewer, and open the findings list manually.")),
-							_("Error"), JOptionPane.ERROR_MESSAGE);
+									translate("RevAger cannot find a PDF viewer on your machine. Please install a PDF Viewer, and open the findings list manually.")),
+							translate("Error"), JOptionPane.ERROR_MESSAGE);
 				}
 			} catch (Exception exc) {
 				UI.getInstance().getExportPDFProtocolDialog().notifySwitchToEditMode();
@@ -156,7 +156,7 @@ public class ExportPDFProtocolWorker extends SwingWorker<Void, Void> {
 					}
 				});
 
-				JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), _("Error"),
+				JOptionPane.showMessageDialog(null, GUITools.getMessagePane(exc.getMessage()), translate("Error"),
 						JOptionPane.ERROR_MESSAGE);
 			}
 

--- a/src/org/revager/gui/workers/ImportAspectsWorker.java
+++ b/src/org/revager/gui/workers/ImportAspectsWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
@@ -73,7 +73,7 @@ public class ImportAspectsWorker extends SwingWorker<Void, Void> {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(_("Importing aspects ..."));
+				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(translate("Importing aspects ..."));
 			}
 		});
 
@@ -85,11 +85,11 @@ public class ImportAspectsWorker extends SwingWorker<Void, Void> {
 				String dir = asp.getDirective();
 
 				if (cate.trim().equals("")) {
-					cate = _("(No Category)");
+					cate = translate("(No Category)");
 				}
 
 				if (dir.trim().equals("")) {
-					dir = _("(No Directive)");
+					dir = translate("(No Directive)");
 				}
 
 				catalog.newAspect(dir, asp.getDescription(), cate);
@@ -98,21 +98,21 @@ public class ImportAspectsWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Aspects imported successfully."),
+					UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Aspects imported successfully."),
 							false);
 				}
 			});
 		} catch (Exception e) {
 			JOptionPane.showMessageDialog(null,
 					GUITools.getMessagePane(
-							_("Cannot import selected file. The content isn't conform to the expected format (Resi XML Schema).")
+							translate("Cannot import selected file. The content isn't conform to the expected format (Resi XML Schema).")
 									+ "\n\n" + e.getMessage()),
-					_("Error"), JOptionPane.ERROR_MESSAGE);
+					translate("Error"), JOptionPane.ERROR_MESSAGE);
 
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Cannot import aspects!"), false);
+					UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Cannot import aspects!"), false);
 				}
 			});
 		}

--- a/src/org/revager/gui/workers/ImportCatalogWorker.java
+++ b/src/org/revager/gui/workers/ImportCatalogWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 
@@ -74,7 +74,7 @@ public class ImportCatalogWorker extends SwingWorker<Void, Void> {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(_("Importing catalog ..."));
+				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(translate("Importing catalog ..."));
 			}
 		});
 
@@ -90,10 +90,10 @@ public class ImportCatalogWorker extends SwingWorker<Void, Void> {
 			boolean firstTime = true;
 
 			while (firstTime || appData.getCatalog(catalogName) != null || catalogName.trim().equals("")) {
-				String title = _("Please enter a new name for the catalog:");
+				String title = translate("Please enter a new name for the catalog:");
 
 				if (!firstTime) {
-					title = _("There is a catalog with the given name already existing. Please enter a new one.")
+					title = translate("There is a catalog with the given name already existing. Please enter a new one.")
 							+ "\n\n" + title;
 				}
 
@@ -113,11 +113,11 @@ public class ImportCatalogWorker extends SwingWorker<Void, Void> {
 				String dir = asp.getDirective();
 
 				if (cate.trim().equals("")) {
-					cate = _("(No Category)");
+					cate = translate("(No Category)");
 				}
 
 				if (dir.trim().equals("")) {
-					dir = _("(No Directive)");
+					dir = translate("(No Directive)");
 				}
 
 				appCat.newAspect(dir, asp.getDescription(), cate);
@@ -128,21 +128,21 @@ public class ImportCatalogWorker extends SwingWorker<Void, Void> {
 				public void run() {
 					UI.getInstance().getAspectsManagerFrame().updateTree();
 
-					UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Catalog imported successfully."),
+					UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Catalog imported successfully."),
 							false);
 				}
 			});
 		} catch (Exception e) {
 			JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
 					GUITools.getMessagePane(
-							_("Cannot import selected file. The content is not conform to the expected format (Resi XML Schema).")
+							translate("Cannot import selected file. The content is not conform to the expected format (Resi XML Schema).")
 									+ "\n\n" + e.getMessage()),
-					_("Error"), JOptionPane.ERROR_MESSAGE);
+					translate("Error"), JOptionPane.ERROR_MESSAGE);
 
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Cannot import catalog!"), false);
+					UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Cannot import catalog!"), false);
 				}
 			});
 		}

--- a/src/org/revager/gui/workers/LoadDefCatalogsWorker.java
+++ b/src/org/revager/gui/workers/LoadDefCatalogsWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.io.File;
 import java.net.URL;
@@ -59,7 +59,7 @@ public class LoadDefCatalogsWorker extends SwingWorker<Void, Void> {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(_("Importing catalog ..."));
+				UI.getInstance().getAspectsManagerFrame().switchToProgressMode(translate("Importing catalog ..."));
 			}
 		});
 
@@ -86,7 +86,7 @@ public class LoadDefCatalogsWorker extends SwingWorker<Void, Void> {
 					@Override
 					public void run() {
 						UI.getInstance().getAspectsManagerFrame()
-								.switchToProgressMode(_("Importing catalog ...") + " " + catalogName);
+								.switchToProgressMode(translate("Importing catalog ...") + " " + catalogName);
 					}
 				});
 
@@ -121,21 +121,21 @@ public class LoadDefCatalogsWorker extends SwingWorker<Void, Void> {
 					public void run() {
 						UI.getInstance().getAspectsManagerFrame().updateTree();
 
-						UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Catalog imported successfully."),
+						UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Catalog imported successfully."),
 								false);
 					}
 				});
 			} catch (Exception e) {
 				JOptionPane.showMessageDialog(UI.getInstance().getAspectsManagerFrame(),
 						GUITools.getMessagePane(
-								_("Cannot import selected file. The content is not conform to the expected format (Resi XML Schema).")
+								translate("Cannot import selected file. The content is not conform to the expected format (Resi XML Schema).")
 										+ "\n\n" + e.getMessage()),
-						_("Error"), JOptionPane.ERROR_MESSAGE);
+						translate("Error"), JOptionPane.ERROR_MESSAGE);
 
 				SwingUtilities.invokeLater(new Runnable() {
 					@Override
 					public void run() {
-						UI.getInstance().getAspectsManagerFrame().setStatusMessage(_("Cannot import catalog!"), false);
+						UI.getInstance().getAspectsManagerFrame().setStatusMessage(translate("Cannot import catalog!"), false);
 					}
 				});
 			}

--- a/src/org/revager/gui/workers/LoadEmbeddedHelpWorker.java
+++ b/src/org/revager/gui/workers/LoadEmbeddedHelpWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import java.awt.BorderLayout;
 
@@ -124,7 +124,7 @@ public class LoadEmbeddedHelpWorker extends SwingWorker<String, Void> {
 			htmlString = "<h1>" + Data.getInstance().getHelpData().getChapterTitle(this.helpChapter) + "</h1>";
 			htmlString = htmlString + Data.getInstance().getHelpData().getChapterContent(this.helpChapter);
 		} catch (DataException exc) {
-			htmlString = "<h1>" + _("Cannot load help information.") + "</h1>";
+			htmlString = "<h1>" + translate("Cannot load help information.") + "</h1>";
 		}
 
 		helpPane.setText(htmlString);

--- a/src/org/revager/gui/workers/LoadReviewWorker.java
+++ b/src/org/revager/gui/workers/LoadReviewWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
@@ -66,7 +66,7 @@ public class LoadReviewWorker extends SwingWorker<Void, Void> {
 			public void run() {
 				mainframe.switchToProgressMode();
 
-				mainframe.setStatusMessage(_("Loading review ..."), true);
+				mainframe.setStatusMessage(translate("Loading review ..."), true);
 
 				UI.getInstance().getAssistantDialog().setVisible(false);
 			}
@@ -82,7 +82,7 @@ public class LoadReviewWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					mainframe.setStatusMessage(_("Review loaded successfully."), false);
+					mainframe.setStatusMessage(translate("Review loaded successfully."), false);
 
 					mainframe.switchToEditMode();
 				}
@@ -93,14 +93,14 @@ public class LoadReviewWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					mainframe.setStatusMessage(_("No review in process."), false);
+					mainframe.setStatusMessage(translate("No review in process."), false);
 
 					mainframe.switchToClearMode();
 				}
 			});
 
 			JOptionPane.showMessageDialog(null,
-					GUITools.getMessagePane(_("Cannot load review file.") + "\n\n" + e.getMessage()), _("Error"),
+					GUITools.getMessagePane(translate("Cannot load review file.") + "\n\n" + e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 
 			SwingUtilities.invokeLater(new Runnable() {

--- a/src/org/revager/gui/workers/NewReviewWorker.java
+++ b/src/org/revager/gui/workers/NewReviewWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
@@ -67,7 +67,7 @@ public class NewReviewWorker extends SwingWorker<Void, Void> {
 			}
 		});
 
-		mainframe.setStatusMessage(_("Creating new review ..."), true);
+		mainframe.setStatusMessage(translate("Creating new review ..."), true);
 
 		try {
 			Application.getInstance().getApplicationCtl().newReview();
@@ -77,7 +77,7 @@ public class NewReviewWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					mainframe.setStatusMessage(_("New review created successfully."), false);
+					mainframe.setStatusMessage(translate("New review created successfully."), false);
 
 					if (instantReview) {
 						UI.getInstance().getEditProductDialog().setVisible(true);
@@ -85,7 +85,7 @@ public class NewReviewWorker extends SwingWorker<Void, Void> {
 						String prodName = Application.getInstance().getReviewMgmt().getProductName();
 
 						if (!prodName.trim().equals("")) {
-							Application.getInstance().getReviewMgmt().setReviewName(_("Review of") + " " + prodName);
+							Application.getInstance().getReviewMgmt().setReviewName(translate("Review of") + " " + prodName);
 						}
 
 						/*
@@ -108,14 +108,14 @@ public class NewReviewWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					mainframe.setStatusMessage(_("No review in process."), false);
+					mainframe.setStatusMessage(translate("No review in process."), false);
 
 					mainframe.switchToClearMode();
 				}
 			});
 
 			JOptionPane.showMessageDialog(UI.getInstance().getMainFrame(),
-					GUITools.getMessagePane(_("Cannot create new review file.") + "\n\n" + e.getMessage()), _("Error"),
+					GUITools.getMessagePane(translate("Cannot create new review file.") + "\n\n" + e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 
 			SwingUtilities.invokeLater(new Runnable() {

--- a/src/org/revager/gui/workers/RestoreReviewWorker.java
+++ b/src/org/revager/gui/workers/RestoreReviewWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
@@ -53,7 +53,7 @@ public class RestoreReviewWorker extends SwingWorker<Void, Void> {
 
 				mainframe.switchToProgressMode();
 
-				mainframe.setStatusMessage(_("Restoring backup ..."), true);
+				mainframe.setStatusMessage(translate("Restoring backup ..."), true);
 			}
 		});
 
@@ -65,7 +65,7 @@ public class RestoreReviewWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					mainframe.setStatusMessage(_("Review restored successfully."), false);
+					mainframe.setStatusMessage(translate("Review restored successfully."), false);
 
 					mainframe.switchToEditMode();
 				}
@@ -76,7 +76,7 @@ public class RestoreReviewWorker extends SwingWorker<Void, Void> {
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
-					mainframe.setStatusMessage(_("No review in process."), false);
+					mainframe.setStatusMessage(translate("No review in process."), false);
 
 					mainframe.switchToClearMode();
 
@@ -89,7 +89,7 @@ public class RestoreReviewWorker extends SwingWorker<Void, Void> {
 			UI.getInstance().setStatus(Status.NO_FILE_LOADED);
 
 			JOptionPane.showMessageDialog(UI.getInstance().getMainFrame(),
-					GUITools.getMessagePane(_("Cannot restore review.") + "\n\n" + e.getMessage()), _("Error"),
+					GUITools.getMessagePane(translate("Cannot restore review.") + "\n\n" + e.getMessage()), translate("Error"),
 					JOptionPane.ERROR_MESSAGE);
 		}
 

--- a/src/org/revager/gui/workers/SaveReviewWorker.java
+++ b/src/org/revager/gui/workers/SaveReviewWorker.java
@@ -18,7 +18,7 @@
  */
 package org.revager.gui.workers;
 
-import static org.revager.app.model.Data._;
+import static org.revager.app.model.Data.translate;
 
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
@@ -69,7 +69,7 @@ public class SaveReviewWorker extends SwingWorker<Void, Void> {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				mainframe.switchToProgressMode(_("Saving review ..."));
+				mainframe.switchToProgressMode(translate("Saving review ..."));
 			}
 		});
 
@@ -83,7 +83,7 @@ public class SaveReviewWorker extends SwingWorker<Void, Void> {
 				public void run() {
 					mainframe.switchToEditMode();
 
-					mainframe.setStatusMessage(_("Review saved successfully."), false);
+					mainframe.setStatusMessage(translate("Review saved successfully."), false);
 				}
 			});
 
@@ -100,14 +100,14 @@ public class SaveReviewWorker extends SwingWorker<Void, Void> {
 				public void run() {
 					mainframe.switchToEditMode();
 
-					mainframe.setStatusMessage(_("Cannot save review file."), false);
+					mainframe.setStatusMessage(translate("Cannot save review file."), false);
 				}
 			});
 
 			JOptionPane.showMessageDialog(UI.getInstance().getMainFrame(),
 					GUITools.getMessagePane(
-							_("Cannot save review file.") + "\n\n" + filePath + "\n\n" + e.getMessage()),
-					_("Error"), JOptionPane.ERROR_MESSAGE);
+							translate("Cannot save review file.") + "\n\n" + filePath + "\n\n" + e.getMessage()),
+					translate("Error"), JOptionPane.ERROR_MESSAGE);
 		}
 
 		return null;


### PR DESCRIPTION
_ should not be used as method name and causes dozens of warnings.

Conversion done with:

<pre>
find . -type f -name "*java*" -exec sed -i 's/_(/translate(/g' {} +
find . -type f -name "*java*" -exec sed -i 's/model.Data._/model.Data.translate/g' {} +</pre>